### PR TITLE
Add `failed_shards` in task error

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: 11
 
       - name: Launch elastic docker
-        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:8.11.4
+        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:8.12.2
 
       - name: run tests
         run: sbt ++2.12.12 test
@@ -65,7 +65,7 @@ jobs:
           java-version: 11
 
       - name: Launch elastic docker
-        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:8.11.4
+        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:8.12.2
 
       - name: run tests
         run: sbt ++2.13.4 test
@@ -105,7 +105,7 @@ jobs:
           java-version: 11
 
       - name: Launch elastic docker
-        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:8.11.4
+        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:8.12.2
 
       - name: run tests
         run: sbt ++3.3.0 elastic4s-scala3/test

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: 11
 
       - name: Launch elastic docker
-        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:8.11.4
+        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:8.12.2
 
       - name: run tests
         timeout-minutes: 30
@@ -42,7 +42,7 @@ jobs:
           java-version: 11
 
       - name: Launch elastic docker
-        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:8.11.4
+        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:8.12.2
 
       - name: run tests
         timeout-minutes: 30
@@ -62,7 +62,7 @@ jobs:
           java-version: 11
 
       - name: Launch elastic docker
-        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:8.11.4
+        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:8.12.2
 
       - name: run tests
         run: sbt ++3.3.0 elastic4s-scala3/test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
           java-version: 11
 
       - name: Launch elastic docker
-        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:8.11.4
+        run: docker run -d -it -p 39227:9200 -p 39337:9300 -e "discovery.type=single-node" -v /home/runner/work/elastic4s/elastic4s/elastic4s-tests/src/test/resources/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml docker.elastic.co/elasticsearch/elasticsearch:8.12.2
 
       - name: Import GPG key
         id: import_gpg

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.3'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.4
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.12.2
     environment:
       discovery.type: single-node
       network.host: 0.0.0.0

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/task/TaskError.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/task/TaskError.scala
@@ -1,10 +1,12 @@
 package com.sksamuel.elastic4s.requests.task
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.sksamuel.elastic4s.FailedShard
 
 case class TaskError(`type`: String,
                      reason: String,
                      phase: String,
                      grouped: Boolean,
-                     @JsonProperty("caused_by") causedBy: Option[Cause]
+                     @JsonProperty("caused_by") causedBy: Option[Cause],
+                     @JsonProperty("failed_shards") failedShards: Seq[FailedShard] = Seq()
                     )

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
@@ -68,7 +68,7 @@ class GetTaskTest extends AnyWordSpec with Matchers with DockerTests {
       }.await.result.task
 
       // We have to wait because if we get the status too soon, the task has not been executed
-      Thread.sleep(3000)
+      Thread.sleep(10000)
 
       // use the task id from the above task
       val result: GetTaskResponse = client.execute {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
@@ -56,7 +56,7 @@ class GetTaskTest extends AnyWordSpec with Matchers with DockerTests {
       val start = System.currentTimeMillis()
 
       // Build an invalid query to make the update by query task fail
-      val query = (0 until 16000)
+      val query = (0 until 200000)
         .flatMap(i => Seq(TermQuery("foo", i.toString), TermQuery("moo", (i+1).toString), TermQuery("goo" ,(i+2).toString)))
 
       // kick off a task

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
@@ -77,8 +77,6 @@ class GetTaskTest extends AnyWordSpec with Matchers with DockerTests {
           getTask(resp.nodeId, resp.taskId)
         }.await.result
          val elapsed = System.currentTimeMillis() - before
-         println(s"Elapsed time : $elapsed ms")
-         println(result)
          found = result.completed || (elapsed > 60000)
          Thread.sleep(1000)
       }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
@@ -78,6 +78,7 @@ class GetTaskTest extends AnyWordSpec with Matchers with DockerTests {
         }.await.result
          val elapsed = System.currentTimeMillis() - before
          println(s"Elapsed time : $elapsed ms")
+         println(result)
          found = result.error.isDefined || (elapsed > 60000)
          Thread.sleep(1000)
       }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
@@ -1,7 +1,11 @@
 package com.sksamuel.elastic4s.tasks
 
 import com.sksamuel.elastic4s.requests.common.RefreshPolicy
-import com.sksamuel.elastic4s.requests.task.Retries
+import com.sksamuel.elastic4s.requests.searches.queries.QueryStringQuery
+import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
+import com.sksamuel.elastic4s.requests.searches.term.TermQuery
+import com.sksamuel.elastic4s.requests.task.{GetTask, GetTaskResponse, Retries, Task}
+import com.sksamuel.elastic4s.requests.update.UpdateByQueryTask
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
@@ -47,6 +51,34 @@ class GetTaskTest extends AnyWordSpec with Matchers with DockerTests {
       task.status.throttledTime should be(0.millis)
       task.status.noops should be(0)
       task.status.retries should be(Retries(0, 0))
+    }
+
+    "return task information when error occurs" in {
+
+      val start = System.currentTimeMillis()
+
+      // Build an invalid query to make the update by query task fail
+      val query = (0 until 91265)
+        .flatMap(i => Seq(TermQuery("foo", i.toString), TermQuery("moo", (i+1).toString), TermQuery("goo" ,(i+2).toString)))
+
+      // kick off a task
+      val resp: GetTask = client.execute {
+        updateByQueryAsync("get_task_a", BoolQuery(should = query))
+      }.await.result.task
+
+      // use the task id from the above task
+      val result: GetTaskResponse = client.execute {
+        getTask(resp.nodeId, resp.taskId)
+      }.await.result
+
+      result.task.node shouldBe resp.nodeId
+      result.task.id shouldBe resp.taskId
+      result.task.`type` shouldBe "transport"
+      result.task.action shouldBe "indices:data/write/update/byquery"
+      result.task.startTimeInMillis >= start shouldBe true
+      result.error.get.failedShards.length should be > 0
+      val reason = result.error.get.failedShards.head.reason.get
+      reason.`type` shouldBe "query_shard_exception"
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
@@ -76,7 +76,9 @@ class GetTaskTest extends AnyWordSpec with Matchers with DockerTests {
          result = client.execute {
           getTask(resp.nodeId, resp.taskId)
         }.await.result
-        found = result.error.isDefined || (System.currentTimeMillis() - before > 60000)
+         val elapsed = System.currentTimeMillis() - before
+         println(s"Elapsed time : $elapsed ms")
+         found = result.error.isDefined || (elapsed > 60000)
          Thread.sleep(1000)
       }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
@@ -79,7 +79,7 @@ class GetTaskTest extends AnyWordSpec with Matchers with DockerTests {
          val elapsed = System.currentTimeMillis() - before
          println(s"Elapsed time : $elapsed ms")
          println(result)
-         found = result.error.isDefined || (elapsed > 1200000)
+         found = result.completed || (elapsed > 60000)
          Thread.sleep(1000)
       }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
@@ -77,6 +77,7 @@ class GetTaskTest extends AnyWordSpec with Matchers with DockerTests {
           getTask(resp.nodeId, resp.taskId)
         }.await.result
         found = result.error.isDefined || (System.currentTimeMillis() - before > 60000)
+         Thread.sleep(1000)
       }
 
       result.task.node shouldBe resp.nodeId

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
@@ -79,7 +79,7 @@ class GetTaskTest extends AnyWordSpec with Matchers with DockerTests {
          val elapsed = System.currentTimeMillis() - before
          println(s"Elapsed time : $elapsed ms")
          println(result)
-         found = result.error.isDefined || (elapsed > 60000)
+         found = result.error.isDefined || (elapsed > 1200000)
          Thread.sleep(1000)
       }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/tasks/GetTaskTest.scala
@@ -76,7 +76,7 @@ class GetTaskTest extends AnyWordSpec with Matchers with DockerTests {
          result = client.execute {
           getTask(resp.nodeId, resp.taskId)
         }.await.result
-        found = result.error.isDefined || (System.currentTimeMillis() - before > 20000)
+        found = result.error.isDefined || (System.currentTimeMillis() - before > 60000)
       }
 
       result.task.node shouldBe resp.nodeId


### PR DESCRIPTION
Same as in `ElasticError`, add the field `failed_shards` in `TaskError` to be able to get more details when a task fails.