### PR TITLE
Handle docAsUpsert and scriptedUpsert set to false

### DIFF
--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryBodyFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryBodyFnTest.scala
@@ -47,6 +47,16 @@ class UpdateByQueryBodyFnTest extends AnyWordSpec with JsonSugar {
         )
       }
 
+      "script upsert set to false" in {
+        val q = updateById("test", "1234")
+          .script(Script("script", Some("painless")))
+          .scriptedUpsert(false)
+
+        UpdateBuilderFn(q).string should matchJson(
+          """{"script":{"lang":"painless","source":"script"},"scripted_upsert":false}"""
+        )
+      }
+
       "doc update" in {
         val q = updateById("test", "1234")
           .doc("foo" -> "bar")
@@ -63,6 +73,16 @@ class UpdateByQueryBodyFnTest extends AnyWordSpec with JsonSugar {
 
         UpdateBuilderFn(q).string should matchJson(
           """{"doc":{"foo":"bar"},"doc_as_upsert":true}"""
+        )
+      }
+
+      "doc upsert set to false" in {
+        val q = updateById("test", "1234")
+          .doc("foo" -> "bar")
+          .docAsUpsert(false)
+
+        UpdateBuilderFn(q).string should matchJson(
+          """{"doc":{"foo":"bar"},"doc_as_upsert":false}"""
         )
       }
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/update/UpdateBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/update/UpdateBuilderFn.scala
@@ -39,8 +39,8 @@ object UpdateBuilderFn {
       builder.endObject()
     }
 
-    request.docAsUpsert.foreach(_ => builder.field("doc_as_upsert", true))
-    request.scriptedUpsert.foreach(_ => builder.field("scripted_upsert", true))
+    request.docAsUpsert.foreach(docAsUpsert => builder.field("doc_as_upsert", docAsUpsert))
+    request.scriptedUpsert.foreach(scriptedUpsert => builder.field("scripted_upsert", scriptedUpsert))
     request.detectNoop.foreach(detectNoop => builder.field("detect_noop", detectNoop))
 
     builder.endObject()


### PR DESCRIPTION
Applying this PR will handle the docAsUpsert and scriptedUpsert fields if they are set to false as well. Previously it was assumed that if they were set they would be true. Fixes https://github.com/Philippus/elastic4s/issues/3021.