### PR TITLE
Support synonyms api

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s
 
-import com.sksamuel.elastic4s.api.{AggregationApi, AliasesApi, AnalyzeApi, AnalyzerApi, BulkApi, CatsApi, ClearRolesCacheApi, ClusterApi, CollapseApi, CountApi, CreateIndexApi, CreateRoleApi, CreateUserApi, DeleteApi, DeleteIndexApi, DeleteRoleApi, DeleteUserApi, ExistsApi, ExplainApi, ForceMergeApi, GetApi, HighlightApi, IndexAdminApi, IndexApi, IndexRecoveryApi, IndexTemplateApi, IngestApi, KnnApi, LocksApi, MappingApi, NodesApi, NormalizerApi, PipelineAggregationApi, PitApi, QueryApi, ReindexApi, ReloadSearchAnalyzersApi, RoleApi, ScoreApi, ScriptApi, ScrollApi, SearchApi, SearchTemplateApi, SettingsApi, SnapshotApi, SortApi, StoredScriptApi, SuggestionApi, TaskApi, TermVectorApi, TokenFilterApi, TokenizerApi, TypesApi, UpdateApi, UserAdminApi, UserApi, ValidateApi}
+import com.sksamuel.elastic4s.api.{AggregationApi, AliasesApi, AnalyzeApi, AnalyzerApi, BulkApi, CatsApi, ClearRolesCacheApi, ClusterApi, CollapseApi, CountApi, CreateIndexApi, CreateRoleApi, CreateUserApi, DeleteApi, DeleteIndexApi, DeleteRoleApi, DeleteUserApi, ExistsApi, ExplainApi, ForceMergeApi, GetApi, HighlightApi, IndexAdminApi, IndexApi, IndexRecoveryApi, IndexTemplateApi, IngestApi, KnnApi, LocksApi, MappingApi, NodesApi, NormalizerApi, PipelineAggregationApi, PitApi, QueryApi, ReindexApi, ReloadSearchAnalyzersApi, RoleApi, ScoreApi, ScriptApi, ScrollApi, SearchApi, SearchTemplateApi, SettingsApi, SnapshotApi, SortApi, StoredScriptApi, SuggestionApi, SynonymsApi, TaskApi, TermVectorApi, TokenFilterApi, TokenizerApi, TypesApi, UpdateApi, UserAdminApi, UserApi, ValidateApi}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
@@ -52,6 +52,7 @@ trait ElasticApi
     with SortApi
     with StoredScriptApi
     with SuggestionApi
+    with SynonymsApi
     with TaskApi
     with TermVectorApi
     with TokenizerApi

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
@@ -21,6 +21,7 @@ import com.sksamuel.elastic4s.handlers.security.roles.{RoleAdminHandlers, RoleHa
 import com.sksamuel.elastic4s.handlers.security.users.{UserAdminHandlers, UserHandlers}
 import com.sksamuel.elastic4s.handlers.settings.SettingsHandlers
 import com.sksamuel.elastic4s.handlers.snapshot.SnapshotHandlers
+import com.sksamuel.elastic4s.handlers.synonyms.SynonymsHandlers
 import com.sksamuel.elastic4s.handlers.task.TaskHandlers
 import com.sksamuel.elastic4s.handlers.termvectors.TermVectorHandlers
 import com.sksamuel.elastic4s.handlers.update.UpdateHandlers
@@ -61,6 +62,7 @@ with SearchScrollHandlers
 with SettingsHandlers
 with SnapshotHandlers
 with StoredScriptHandlers
+with SynonymsHandlers
 with UpdateHandlers
 with TaskHandlers
 with TermVectorHandlers

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/SynonymsApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/SynonymsApi.scala
@@ -1,0 +1,22 @@
+package com.sksamuel.elastic4s.api
+
+import com.sksamuel.elastic4s.requests.synonyms.{DeleteSynonymRuleRequest, DeleteSynonymsSetRequest, GetSynonymsSetRequest, ListSynonymsSetRequest, SynonymRule, CreateOrUpdateSynonymRuleRequest, CreateOrUpdateSynonymsSetRequest}
+
+trait SynonymsApi {
+  def createOrUpdateSynonymsSet(synonymsSet: String, synonymRules: Seq[SynonymRule]): CreateOrUpdateSynonymsSetRequest =
+    CreateOrUpdateSynonymsSetRequest(synonymsSet, synonymRules)
+
+  def getSynonymsSet(synonymsSet: String, from: Option[Int] = None, size: Option[Int] = None): GetSynonymsSetRequest =
+    GetSynonymsSetRequest(synonymsSet, from, size)
+
+  def listSynonymsSet(from: Option[Int] = None, size: Option[Int] = None): ListSynonymsSetRequest =
+    ListSynonymsSetRequest(from, size)
+
+  def deleteSynonymsSet(synonymsSet: String): DeleteSynonymsSetRequest = DeleteSynonymsSetRequest(synonymsSet)
+
+  def upsertSynonymRule(synonymsSet: String, synonymRule: String, synonyms: String): CreateOrUpdateSynonymRuleRequest =
+    CreateOrUpdateSynonymRuleRequest(synonymsSet, synonymRule, synonyms)
+
+  def deleteSynonymRule(synonymsSet: String, synonymRule: String): DeleteSynonymRuleRequest =
+    DeleteSynonymRuleRequest(synonymsSet, synonymRule)
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/analysis/TokenFilter.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/analysis/TokenFilter.scala
@@ -16,14 +16,16 @@ case class SynonymTokenFilter(override val name: String,
                               expand: Option[Boolean] = None,
                               @deprecated tokenizer: Option[String] = None,
                               updateable: Option[Boolean] = None,
-                              lenient: Option[Boolean] = None) extends TokenFilter {
-  require(path.isDefined || synonyms.nonEmpty, "synonym requires either `synonyms` or `synonyms_path` to be configured")
+                              lenient: Option[Boolean] = None,
+                              synonymsSet: Option[String] = None) extends TokenFilter {
+  require(synonymsSet.isDefined || path.isDefined || synonyms.nonEmpty, "synonym requires either `synonyms_set`, `synonyms_path` or `synonyms` to be configured")
 
   override def build: XContentBuilder = {
     val b = XContentFactory.jsonBuilder()
     b.field("type", "synonym")
-    if (synonyms.isEmpty) path.foreach(b.field("synonyms_path", _))
-    if (synonyms.nonEmpty) b.array("synonyms", synonyms.toArray)
+    if (synonymsSet.nonEmpty) synonymsSet.foreach(b.field("synonyms_set", _))
+    else if (path.nonEmpty) path.foreach(b.field("synonyms_path", _))
+    else b.array("synonyms", synonyms.toArray)
     format.foreach(b.field("format", _))
     ignoreCase.foreach(b.field("ignore_case", _))
     updateable.foreach(b.field("updateable", _))
@@ -106,15 +108,17 @@ case class SynonymGraphTokenFilter(override val name: String,
                                    expand: Option[Boolean] = None,
                                    @deprecated tokenizer: Option[String] = None,
                                    updateable: Option[Boolean] = None,
-                                   lenient: Option[Boolean] = None) extends TokenFilter {
+                                   lenient: Option[Boolean] = None,
+                                   synonymsSet: Option[String] = None) extends TokenFilter {
 
-  require(path.isDefined || synonyms.nonEmpty, "synonym_graph requires either `synonyms` or `synonyms_path` to be configured")
+  require(synonymsSet.isDefined || path.isDefined || synonyms.nonEmpty, "synonym requires either `synonyms_set`, `synonyms_path` or `synonyms` to be configured")
 
   override def build: XContentBuilder = {
     val b = XContentFactory.jsonBuilder()
     b.field("type", "synonym_graph")
-    if (synonyms.isEmpty) path.foreach(b.field("synonyms_path", _))
-    if (synonyms.nonEmpty) b.array("synonyms", synonyms.toArray)
+    if (synonymsSet.nonEmpty) synonymsSet.foreach(b.field("synonyms_set", _))
+    else if (path.nonEmpty) path.foreach(b.field("synonyms_path", _))
+    else b.array("synonyms", synonyms.toArray)
     format.foreach(b.field("format", _))
     ignoreCase.foreach(b.field("ignore_case", _))
     updateable.foreach(b.field("updateable", _))

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/CreateOrUpdateSynonymRuleRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/CreateOrUpdateSynonymRuleRequest.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+case class CreateOrUpdateSynonymRuleRequest(synonymsSet: String, synonymRule: String, synonyms: String)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/CreateOrUpdateSynonymsSetRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/CreateOrUpdateSynonymsSetRequest.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+case class CreateOrUpdateSynonymsSetRequest(synonymsSet: String, synonymRules: Seq[SynonymRule])

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/DeleteSynonymRuleRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/DeleteSynonymRuleRequest.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+case class DeleteSynonymRuleRequest(synonymsSet: String, synonymRule: String)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/DeleteSynonymRuleResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/DeleteSynonymRuleResponse.scala
@@ -1,0 +1,6 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class DeleteSynonymRuleResponse(result: String,
+                                     @JsonProperty("reload_analyzers_details") reloadAnalyzersDetails: ReloadAnalyzersDetails)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/DeleteSynonymsSetRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/DeleteSynonymsSetRequest.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+case class DeleteSynonymsSetRequest(synonymsSet: String)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/GetSynonymRuleRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/GetSynonymRuleRequest.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+case class GetSynonymRuleRequest(synonymsSet: String, synonymRule: String)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/GetSynonymRuleResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/GetSynonymRuleResponse.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+case class GetSynonymRuleResponse(id: String, synonyms: String)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/GetSynonymsSetRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/GetSynonymsSetRequest.scala
@@ -1,0 +1,6 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+case class GetSynonymsSetRequest(synonymsSet: String, from: Option[Int] = None, size: Option[Int] = None) {
+  def from(from: Int): GetSynonymsSetRequest = copy(from = Some(from))
+  def size(size: Int): GetSynonymsSetRequest = copy(size = Some(size))
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/GetSynonymsSetResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/GetSynonymsSetResponse.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+case class GetSynonymsSetResponse(count: Int, synonymsSet: Seq[SynonymRule])

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/ListSynonymsSetRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/ListSynonymsSetRequest.scala
@@ -1,0 +1,6 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+case class ListSynonymsSetRequest(from: Option[Int], size: Option[Int]) {
+  def from(from: Int): ListSynonymsSetRequest = copy(from = Some(from))
+  def size(size: Int): ListSynonymsSetRequest = copy(size = Some(size))
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/ListSynonymsSetResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/ListSynonymsSetResponse.scala
@@ -1,0 +1,6 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class ListSynonymsResult(@JsonProperty("synonyms_set") synonymsSet: String, count: Int)
+case class ListSynonymsSetResponse(count: Int, results: Seq[ListSynonymsResult])

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/ReloadDetails.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/ReloadDetails.scala
@@ -1,0 +1,9 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.sksamuel.elastic4s.requests.common.Shards
+
+case class ReloadDetails(index: String, @JsonProperty("reloaded_analyzers") reloadedAnalyzers: Seq[String],
+                         @JsonProperty("reloaded_node_ids") reloadedNodeIds: Seq[String])
+case class ReloadAnalyzersDetails(@JsonProperty("reload_details") reloadDetails: Seq[ReloadDetails],
+                                  @JsonProperty("_shards") shards: Option[Shards])

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/SynonymRule.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/SynonymRule.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+case class SynonymRule(synonyms: String, id: Option[String] = None)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/UpdateSynonymRuleResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/UpdateSynonymRuleResponse.scala
@@ -1,0 +1,6 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class UpdateSynonymRuleResponse(result: String,
+                                     @JsonProperty("reload_analyzers_details") reloadAnalyzersDetails: ReloadAnalyzersDetails)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/UpdateSynonymsSetResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/UpdateSynonymsSetResponse.scala
@@ -1,0 +1,6 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class UpdateSynonymsSetResponse(result: String,
+                                     @JsonProperty("reload_analyzers_details") reloadAnalyzersDetails: ReloadAnalyzersDetails)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/synonyms/SynonymsHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/synonyms/SynonymsHandlers.scala
@@ -1,0 +1,133 @@
+package com.sksamuel.elastic4s.handlers.synonyms
+
+import com.sksamuel.elastic4s.handlers.ElasticErrorParser
+import com.sksamuel.elastic4s.requests.synonyms.{DeleteSynonymRuleRequest, DeleteSynonymRuleResponse, DeleteSynonymsSetRequest, GetSynonymRuleRequest, GetSynonymRuleResponse, GetSynonymsSetRequest, GetSynonymsSetResponse, ListSynonymsSetRequest, ListSynonymsSetResponse, CreateOrUpdateSynonymRuleRequest, UpdateSynonymRuleResponse, CreateOrUpdateSynonymsSetRequest, UpdateSynonymsSetResponse}
+import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, Handler, HttpEntity, HttpResponse, ResponseHandler}
+
+trait SynonymsHandlers {
+  implicit object UpdateSynonymsSetHandler extends Handler[CreateOrUpdateSynonymsSetRequest, UpdateSynonymsSetResponse] {
+
+    override def responseHandler: ResponseHandler[UpdateSynonymsSetResponse] = new ResponseHandler[UpdateSynonymsSetResponse] {
+      override def handle(response: HttpResponse): Either[ElasticError, UpdateSynonymsSetResponse] = {
+        response.statusCode match {
+          case 200 | 201 => Right(ResponseHandler.fromResponse[UpdateSynonymsSetResponse](response))
+          case 400 => Left(ElasticErrorParser.parse(response))
+          case _ => sys.error("Invalid response")
+        }
+      }
+    }
+
+    override def build(request: CreateOrUpdateSynonymsSetRequest): ElasticRequest = {
+      val endpoint = s"_synonyms/${request.synonymsSet}"
+
+      val body = UpdateSynonymsBodyFn(request).string
+      val entity = HttpEntity(body, "application/json")
+
+      ElasticRequest("PUT", endpoint, entity)
+    }
+  }
+
+  implicit object GetSynonymsSetHandler extends Handler[GetSynonymsSetRequest, GetSynonymsSetResponse] {
+      override def responseHandler: ResponseHandler[GetSynonymsSetResponse] = new ResponseHandler[GetSynonymsSetResponse] {
+        override def handle(response: HttpResponse): Either[ElasticError, GetSynonymsSetResponse] =
+          response.statusCode match {
+            case 200 => Right(ResponseHandler.fromResponse[GetSynonymsSetResponse](response))
+            case 400 | 404  => Left(ElasticErrorParser.parse(response))
+            case _ => sys.error("Invalid response")
+          }
+      }
+
+      override def build(request: GetSynonymsSetRequest): ElasticRequest = {
+        val endpoint = s"_synonyms/${request.synonymsSet}"
+        val params = scala.collection.mutable.Map.empty[String, String]
+        request.from.foreach(from => params.put("from", from.toString))
+        request.size.foreach(size => params.put("size", size.toString))
+        ElasticRequest("GET", endpoint, params.toMap)
+      }
+  }
+
+  implicit object ListSynonymsSetHandler extends Handler[ListSynonymsSetRequest, ListSynonymsSetResponse] {
+    override def responseHandler: ResponseHandler[ListSynonymsSetResponse] = new ResponseHandler[ListSynonymsSetResponse] {
+      override def handle(response: HttpResponse): Either[ElasticError, ListSynonymsSetResponse] =
+        response.statusCode match {
+          case 200 => Right(ResponseHandler.fromResponse[ListSynonymsSetResponse](response))
+          case _ => sys.error("Invalid response")
+        }
+    }
+
+    override def build(request: ListSynonymsSetRequest): ElasticRequest = {
+      val endpoint = "_synonyms"
+      val params = scala.collection.mutable.Map.empty[String, String]
+      request.from.foreach(from => params.put("from", from.toString))
+      request.size.foreach(size => params.put("size", size.toString))
+      ElasticRequest("GET", endpoint, params.toMap)
+    }
+  }
+
+  implicit object DeleteSynonymsSetHandler extends Handler[DeleteSynonymsSetRequest, Unit] {
+    override def responseHandler: ResponseHandler[Unit] = new ResponseHandler[Unit] {
+      override def handle(response: HttpResponse): Either[ElasticError, Unit] =
+        response.statusCode match {
+          case 200 => Right(())
+          case 400 | 404 => Left(ElasticErrorParser.parse(response))
+          case _ => sys.error("Invalid response")
+        }
+    }
+
+    override def build(request: DeleteSynonymsSetRequest): ElasticRequest = {
+      val endpoint = s"_synonyms/${request.synonymsSet}"
+      ElasticRequest("DELETE", endpoint)
+    }
+  }
+
+  implicit object UpdateSynonymRuleHandler extends Handler[CreateOrUpdateSynonymRuleRequest, UpdateSynonymRuleResponse] {
+    override def responseHandler: ResponseHandler[UpdateSynonymRuleResponse] = new ResponseHandler[UpdateSynonymRuleResponse] {
+      override def handle(response: HttpResponse): Either[ElasticError, UpdateSynonymRuleResponse] =
+        response.statusCode match {
+          case 200 | 201 => Right(ResponseHandler.fromResponse[UpdateSynonymRuleResponse](response))
+          case 400 | 404 => Left(ElasticErrorParser.parse(response))
+          case _ => sys.error("Invalid response")
+        }
+    }
+
+    override def build(request: CreateOrUpdateSynonymRuleRequest): ElasticRequest = {
+      val endpoint = s"_synonyms/${request.synonymsSet}/${request.synonymRule}"
+      println(endpoint)
+      val body = UpdateSynonymRuleBodyFn(request).string
+      val entity = HttpEntity(body, "application/json")
+      ElasticRequest("PUT", endpoint, entity)
+    }
+  }
+
+  implicit object GetSynonymRuleHandler extends Handler[GetSynonymRuleRequest, GetSynonymRuleResponse] {
+    override def responseHandler: ResponseHandler[GetSynonymRuleResponse] = new ResponseHandler[GetSynonymRuleResponse] {
+      override def handle(response: HttpResponse): Either[ElasticError, GetSynonymRuleResponse] =
+        response.statusCode match {
+          case 200 => Right(ResponseHandler.fromResponse[GetSynonymRuleResponse](response))
+          case 404 => Left(ElasticErrorParser.parse(response))
+          case _ => sys.error("Invalid response")
+        }
+    }
+
+    override def build(request: GetSynonymRuleRequest): ElasticRequest = {
+      val endpoint = s"_synonyms/${request.synonymsSet}/${request.synonymRule}"
+      ElasticRequest("GET", endpoint)
+    }
+  }
+
+  implicit object DeleteSynonymRuleHandler extends Handler[DeleteSynonymRuleRequest, DeleteSynonymRuleResponse] {
+    override def responseHandler: ResponseHandler[DeleteSynonymRuleResponse] = new ResponseHandler[DeleteSynonymRuleResponse] {
+      override def handle(response: HttpResponse): Either[ElasticError, DeleteSynonymRuleResponse] =
+        response.statusCode match {
+          case 200 => Right(ResponseHandler.fromResponse[DeleteSynonymRuleResponse](response))
+          case 404 => Left(ElasticErrorParser.parse(response))
+          case _ => sys.error("Invalid response")
+        }
+    }
+
+    override def build(request: DeleteSynonymRuleRequest): ElasticRequest = {
+      val endpoint = s"_synonyms/${request.synonymsSet}/${request.synonymRule}"
+      ElasticRequest("DELETE", endpoint)
+    }
+  }
+}

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/synonyms/UpdateSynonymRuleBodyFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/synonyms/UpdateSynonymRuleBodyFn.scala
@@ -1,0 +1,11 @@
+package com.sksamuel.elastic4s.handlers.synonyms
+
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+import com.sksamuel.elastic4s.requests.synonyms.CreateOrUpdateSynonymRuleRequest
+
+object UpdateSynonymRuleBodyFn {
+  def apply(request: CreateOrUpdateSynonymRuleRequest): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.field("synonyms", request.synonyms)
+  }
+}

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/synonyms/UpdateSynonymsBodyFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/synonyms/UpdateSynonymsBodyFn.scala
@@ -1,0 +1,18 @@
+package com.sksamuel.elastic4s.handlers.synonyms
+
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+import com.sksamuel.elastic4s.requests.synonyms.CreateOrUpdateSynonymsSetRequest
+
+object UpdateSynonymsBodyFn {
+  def apply(request: CreateOrUpdateSynonymsSetRequest): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.startArray("synonyms_set")
+    request.synonymRules.foreach { rule =>
+      builder.startObject()
+      rule.id.foreach(builder.field("id", _))
+      builder.field("synonyms", rule.synonyms)
+      builder.endObject()
+    }
+    builder.endArray()
+  }
+}

--- a/elastic4s-tests/src/test/resources/json/analysis/tokenfilter/synonymgraphtokenfilter_set_raw.json
+++ b/elastic4s-tests/src/test/resources/json/analysis/tokenfilter/synonymgraphtokenfilter_set_raw.json
@@ -1,0 +1,10 @@
+{
+    "type": "synonym_graph",
+    "synonyms_set": "my_synonyms_set",
+    "format": "solr",
+    "ignore_case": true,
+    "updateable": true,
+    "expand": true,
+    "lenient": true,
+    "tokenizer": "whitespace"
+}

--- a/elastic4s-tests/src/test/resources/json/analysis/tokenfilter/synonymtokenfilter_set_raw.json
+++ b/elastic4s-tests/src/test/resources/json/analysis/tokenfilter/synonymtokenfilter_set_raw.json
@@ -1,0 +1,10 @@
+{
+    "type": "synonym",
+    "synonyms_set": "my_synonyms_set",
+    "format": "solr",
+    "ignore_case": true,
+    "updateable": true,
+    "expand": true,
+    "lenient": true,
+    "tokenizer": "whitespace"
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/TokenFilterTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/analysis/TokenFilterTest.scala
@@ -6,20 +6,18 @@ import org.scalatest.wordspec.AnyWordSpec
 
 class TokenFilterTest extends AnyWordSpec with Matchers with JsonSugar {
   "SynonymTokenFilter" should {
-    "build json with synonyms" in {
+    "build json with synonyms set" in {
       SynonymTokenFilter(
         name = "my_synonym",
-        path = Option("analysis/synonyms.txt"),
-        synonyms = Set("british,english", "queen,monarch"),
         ignoreCase = Option(true),
         format = Option("solr"),
         expand = Option(true),
         tokenizer = Option("whitespace"),
         updateable = Option(true),
-        lenient = Option(true)
-      ).build.string should matchJsonResource("/json/analysis/tokenfilter/synonymtokenfilter_synonyms_raw.json")
+        lenient = Option(true),
+        synonymsSet = Option("my_synonyms_set")
+      ).build.string should matchJsonResource("/json/analysis/tokenfilter/synonymtokenfilter_set_raw.json")
     }
-
     "build json with path" in {
       SynonymTokenFilter(
         name = "my_synonym",
@@ -32,13 +30,9 @@ class TokenFilterTest extends AnyWordSpec with Matchers with JsonSugar {
         lenient = Option(true)
       ).build.string should matchJsonResource("/json/analysis/tokenfilter/synonymtokenfilter_path_raw.json")
     }
-  }
-
-  "SynonymGraphTokenFilter" should {
     "build json with synonyms" in {
-      SynonymGraphTokenFilter(
+      SynonymTokenFilter(
         name = "my_synonym",
-        path = Option("analysis/synonyms.txt"),
         synonyms = Set("british,english", "queen,monarch"),
         ignoreCase = Option(true),
         format = Option("solr"),
@@ -46,9 +40,23 @@ class TokenFilterTest extends AnyWordSpec with Matchers with JsonSugar {
         tokenizer = Option("whitespace"),
         updateable = Option(true),
         lenient = Option(true)
-      ).build.string should matchJsonResource("/json/analysis/tokenfilter/synonymgraphtokenfilter_synonyms_raw.json")
+      ).build.string should matchJsonResource("/json/analysis/tokenfilter/synonymtokenfilter_synonyms_raw.json")
     }
+  }
 
+  "SynonymGraphTokenFilter" should {
+    "build json with synonyms set" in {
+      SynonymGraphTokenFilter(
+        name = "my_synonym",
+        ignoreCase = Option(true),
+        format = Option("solr"),
+        expand = Option(true),
+        tokenizer = Option("whitespace"),
+        updateable = Option(true),
+        lenient = Option(true),
+        synonymsSet = Option("my_synonyms_set")
+      ).build.string should matchJsonResource("/json/analysis/tokenfilter/synonymgraphtokenfilter_set_raw.json")
+    }
     "build json with path" in {
       SynonymGraphTokenFilter(
         name = "my_synonym",
@@ -60,6 +68,18 @@ class TokenFilterTest extends AnyWordSpec with Matchers with JsonSugar {
         updateable = Option(true),
         lenient = Option(true)
       ).build.string should matchJsonResource("/json/analysis/tokenfilter/synonymgraphtokenfilter_path_raw.json")
+    }
+    "build json with synonyms" in {
+      SynonymGraphTokenFilter(
+        name = "my_synonym",
+        synonyms = Set("british,english", "queen,monarch"),
+        ignoreCase = Option(true),
+        format = Option("solr"),
+        expand = Option(true),
+        tokenizer = Option("whitespace"),
+        updateable = Option(true),
+        lenient = Option(true)
+      ).build.string should matchJsonResource("/json/analysis/tokenfilter/synonymgraphtokenfilter_synonyms_raw.json")
     }
   }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/synonyms/SynonymsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/synonyms/SynonymsTest.scala
@@ -1,0 +1,85 @@
+package com.sksamuel.elastic4s.requests.synonyms
+
+import scala.util.Try
+
+import com.sksamuel.elastic4s.ElasticDsl
+import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class SynonymsTest extends AnyFlatSpec with Matchers with ElasticDsl with DockerTests {
+  Try {
+    client.execute {
+      deleteSynonymsSet("my-synonyms-set")
+    }.await.result
+  }
+
+  "synonyms" should "create a new set" in {
+    val resp = client.execute {
+      createOrUpdateSynonymsSet("my-synonyms-set", Seq(SynonymRule(id = Some("test-1"), synonyms = "hello, hi"), SynonymRule("bye, goodbye"), SynonymRule(id = Some("test-2"), synonyms = "test => check")))
+    }.await.result
+
+    resp.result shouldBe "created"
+  }
+
+  it should "return a created set" in {
+    val resp = client.execute {
+      getSynonymsSet("my-synonyms-set")
+    }.await.result
+
+    resp.count shouldBe 3
+  }
+
+  it should "handle errors" in {
+    client.execute {
+      getSynonymsSet("not-a-set")
+    }.await.isError shouldBe true
+  }
+
+  it should "list all sets" in {
+    val resp = client.execute {
+      listSynonymsSet()
+    }.await.result
+
+    resp.count shouldBe 1
+    resp.results.size shouldBe 1
+    resp.results.map(_.synonymsSet).head shouldBe "my-synonyms-set"
+    resp.results.map(_.count).head shouldBe 3
+  }
+
+  it should "delete a set" in {
+    client.execute {
+      deleteSynonymsSet("my-synonyms-set")
+    }.await.result
+
+    val resp = client.execute {
+      listSynonymsSet()
+    }.await.result
+
+    resp.count shouldBe 0
+  }
+
+  it should "update an existing rule" in {
+    client.execute {
+      createOrUpdateSynonymsSet("my-synonyms-set", Seq(SynonymRule(id = Some("test-1"), synonyms = "hello, hi"), SynonymRule("bye, goodbye"), SynonymRule(id = Some("test-2"), synonyms = "test => check")))
+    }.await.result
+
+    val resp = client.execute {
+      upsertSynonymRule("my-synonyms-set", "test-1", "hello, hi, howdy")
+    }.await.result
+
+    resp.result shouldBe "updated"
+  }
+
+  it should "delete a synonym rule" in {
+    client.execute {
+      createOrUpdateSynonymsSet("my-synonyms-set", Seq(SynonymRule(id = Some("test-1"), synonyms = "hello, hi"), SynonymRule("bye, goodbye"), SynonymRule(id = Some("test-2"), synonyms = "test => check")))
+    }.await.result
+
+    val resp = client.execute {
+      deleteSynonymRule("my-synonyms-set", "test-1")
+    }.await.result
+
+    resp.result shouldBe "deleted"
+  }
+}


### PR DESCRIPTION
Applying this PR will add support for the [Synonyms API](https://www.elastic.co/guide/en/elasticsearch/reference/8.13/synonyms-apis.html). Resolves https://github.com/Philippus/elastic4s/issues/3035.