### PR TITLE
Support terms enum api

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s
 
-import com.sksamuel.elastic4s.api.{AggregationApi, AliasesApi, AnalyzeApi, AnalyzerApi, BulkApi, CatsApi, ClearRolesCacheApi, ClusterApi, CollapseApi, CountApi, CreateIndexApi, CreateRoleApi, CreateUserApi, DeleteApi, DeleteIndexApi, DeleteRoleApi, DeleteUserApi, ExistsApi, ExplainApi, ForceMergeApi, GetApi, HighlightApi, IndexAdminApi, IndexApi, IndexRecoveryApi, IndexTemplateApi, IngestApi, KnnApi, LocksApi, MappingApi, NodesApi, NormalizerApi, PipelineAggregationApi, PitApi, QueryApi, ReindexApi, ReloadSearchAnalyzersApi, RoleApi, ScoreApi, ScriptApi, ScrollApi, SearchApi, SearchTemplateApi, SettingsApi, SnapshotApi, SortApi, StoredScriptApi, SuggestionApi, TaskApi, TermVectorApi, TokenFilterApi, TokenizerApi, TypesApi, UpdateApi, UserAdminApi, UserApi, ValidateApi}
+import com.sksamuel.elastic4s.api.{AggregationApi, AliasesApi, AnalyzeApi, AnalyzerApi, BulkApi, CatsApi, ClearRolesCacheApi, ClusterApi, CollapseApi, CountApi, CreateIndexApi, CreateRoleApi, CreateUserApi, DeleteApi, DeleteIndexApi, DeleteRoleApi, DeleteUserApi, ExistsApi, ExplainApi, ForceMergeApi, GetApi, HighlightApi, IndexAdminApi, IndexApi, IndexRecoveryApi, IndexTemplateApi, IngestApi, KnnApi, LocksApi, MappingApi, NodesApi, NormalizerApi, PipelineAggregationApi, PitApi, QueryApi, ReindexApi, ReloadSearchAnalyzersApi, RoleApi, ScoreApi, ScriptApi, ScrollApi, SearchApi, SearchTemplateApi, SettingsApi, SnapshotApi, SortApi, StoredScriptApi, SuggestionApi, TaskApi, TermVectorApi, TermsEnumApi, TokenFilterApi, TokenizerApi, TypesApi, UpdateApi, UserAdminApi, UserApi, ValidateApi}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
@@ -54,6 +54,7 @@ trait ElasticApi
     with SuggestionApi
     with TaskApi
     with TermVectorApi
+    with TermsEnumApi
     with TokenizerApi
     with TokenFilterApi
     with TypesApi

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
@@ -22,6 +22,7 @@ import com.sksamuel.elastic4s.handlers.security.users.{UserAdminHandlers, UserHa
 import com.sksamuel.elastic4s.handlers.settings.SettingsHandlers
 import com.sksamuel.elastic4s.handlers.snapshot.SnapshotHandlers
 import com.sksamuel.elastic4s.handlers.task.TaskHandlers
+import com.sksamuel.elastic4s.handlers.termsenum.TermsEnumHandlers
 import com.sksamuel.elastic4s.handlers.termvectors.TermVectorHandlers
 import com.sksamuel.elastic4s.handlers.update.UpdateHandlers
 import com.sksamuel.elastic4s.handlers.validate.ValidateHandlers
@@ -64,6 +65,7 @@ with StoredScriptHandlers
 with UpdateHandlers
 with TaskHandlers
 with TermVectorHandlers
+with TermsEnumHandlers
 with UserAdminHandlers
 with UserHandlers
 with ValidateHandlers

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/TermsEnumApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/TermsEnumApi.scala
@@ -1,0 +1,13 @@
+package com.sksamuel.elastic4s.api
+
+import com.sksamuel.elastic4s.Indexes
+import com.sksamuel.elastic4s.requests.termsenum.TermsEnumRequest
+trait TermsEnumApi {
+  def termsEnum(index: String, field: String): TermsEnumRequest = TermsEnumRequest(Indexes(index), field)
+  def termsEnum(indexes: Indexes, field: String): TermsEnumRequest = TermsEnumRequest(indexes, field)
+  def termsEnum(indexes: Seq[String], field: String): TermsEnumRequest = TermsEnumRequest(Indexes(indexes), field)
+
+  def termsEnum(index: String, field: String, string: String): TermsEnumRequest = TermsEnumRequest(Indexes(index), field, string = Some(string))
+  def termsEnum(indexes: Indexes, field: String, string: String): TermsEnumRequest = TermsEnumRequest(indexes, field, string = Some(string))
+  def termsEnum(indexes: Seq[String], field: String, string: String): TermsEnumRequest = TermsEnumRequest(Indexes(indexes), field, string = Some(string))
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/termsenum/TermsEnumRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/termsenum/TermsEnumRequest.scala
@@ -1,0 +1,22 @@
+package com.sksamuel.elastic4s.requests.termsenum
+
+import com.sksamuel.elastic4s.Indexes
+import com.sksamuel.elastic4s.requests.searches.queries.Query
+import com.sksamuel.elastic4s.ext.OptionImplicits._
+
+case class TermsEnumRequest(indexes: Indexes,
+                            field: String,
+                            string: Option[String] = None,
+                            size: Option[Int] = None,
+                            timeout: Option[String] = None,
+                            caseInsensitive: Option[Boolean] = None,
+                            indexFilter: Option[Query] = None,
+                            searchAfter: Option[String] = None
+                           ) extends Serializable {
+  def string(string: String): TermsEnumRequest = copy(string = string.some)
+  def size(size: Int): TermsEnumRequest = copy(size = size.some)
+  def timeout(timeout: String): TermsEnumRequest = copy(timeout = timeout.some)
+  def caseInsensitive(caseInsensitive: Boolean): TermsEnumRequest = copy(caseInsensitive = caseInsensitive.some)
+  def indexFilter(indexFilter: Query): TermsEnumRequest = copy(indexFilter = indexFilter.some)
+  def searchAfter(searchAfter: String): TermsEnumRequest = copy(searchAfter = searchAfter.some)
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/termsenum/TermsEnumResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/termsenum/TermsEnumResponse.scala
@@ -1,0 +1,8 @@
+package com.sksamuel.elastic4s.requests.termsenum
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.sksamuel.elastic4s.requests.common.Shards
+
+case class TermsEnumResponse(terms: Seq[String], complete: Boolean, @JsonProperty("_shards") shards: Shards) {
+  def isComplete: Boolean = complete
+}

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/termsenum/TermsEnumHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/termsenum/TermsEnumHandlers.scala
@@ -1,0 +1,34 @@
+package com.sksamuel.elastic4s.handlers.termsenum
+
+import com.sksamuel.elastic4s.handlers.searches.queries
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+import com.sksamuel.elastic4s.requests.termsenum.{TermsEnumRequest, TermsEnumResponse}
+import com.sksamuel.elastic4s.{ElasticRequest, Handler, HttpEntity}
+
+object TermsEnumBodyFn {
+  def apply(request: TermsEnumRequest): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.field("field", request.field)
+    request.string.foreach(builder.field("string", _))
+    request.size.foreach(builder.field("size", _))
+    request.timeout.foreach(builder.field("timeout", _))
+    request.caseInsensitive.foreach(builder.field("case_insensitive", _))
+    request.indexFilter.foreach(q => builder.rawField("index_filter", queries.QueryBuilderFn(q)))
+    request.searchAfter.foreach(builder.field("search_after", _))
+    builder.endObject()
+  }
+}
+
+trait TermsEnumHandlers {
+  implicit object TermsEnumHandler extends Handler[TermsEnumRequest, TermsEnumResponse] {
+    override def build(request: TermsEnumRequest): ElasticRequest = {
+
+      val endpoint = s"/${request.indexes.values.mkString(",")}/_terms_enum"
+
+      val body   = TermsEnumBodyFn(request).string
+      val entity = HttpEntity(body, "application/json")
+
+      ElasticRequest("POST", endpoint, entity)
+    }
+  }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/termsenum/TermsEnumTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/termsenum/TermsEnumTest.scala
@@ -1,0 +1,63 @@
+package com.sksamuel.elastic4s.requests.termsenum
+
+import scala.util.Try
+
+import com.sksamuel.elastic4s.handlers.termsenum.TermsEnumBodyFn
+import com.sksamuel.elastic4s.requests.common.RefreshPolicy
+import com.sksamuel.elastic4s.requests.searches.term.TermQuery
+import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class TermsEnumTest extends AnyWordSpec with Matchers with DockerTests {
+  Try {
+    client.execute {
+      deleteIndex("test")
+    }.await
+  }
+
+  client.execute {
+    createIndex("test").mapping(
+      properties(
+        keywordField("tags"),
+      )
+    )
+  }.await
+
+  client.execute {
+    indexInto("test") fields(
+      "tags" -> "kibana"
+    ) refresh RefreshPolicy.WaitFor
+  }.await
+
+  "a minimal terms enum query" should {
+    "return proper response" in {
+      val resp = client.execute {
+        termsEnum("test", "tags", "kiba")
+      }.await.result
+      resp.terms shouldBe Seq("kibana")
+      resp.isComplete shouldBe true
+    }
+
+   val termsEnumRequest = TermsEnumRequest("test", "tags")
+      .string("kiba")
+      .size(3)
+      .timeout("1m")
+      .caseInsensitive(false)
+      .indexFilter(TermQuery("tags", "kiba"))
+      .searchAfter("kiba")
+
+    "support all fields in the builder" in {
+      TermsEnumBodyFn(termsEnumRequest).string shouldEqual
+        """{"field":"tags","string":"kiba","size":3,"timeout":"1m","case_insensitive":false,"index_filter":{"term":{"tags":{"value":"kiba"}}},"search_after":"kiba"}"""
+    }
+
+    "return a response when all fields are present" in {
+      val resp = client.execute {
+        termsEnumRequest
+      }.await.result
+      resp.terms shouldBe Seq("kibana")
+      resp.isComplete shouldBe true
+    }
+  }
+}


### PR DESCRIPTION
Applying this PR will add support for the [Terms Enum API](https://www.elastic.co/guide/en/elasticsearch/reference/8.13/search-terms-enum.html). Resolves https://github.com/Philippus/elastic4s/issues/2908.