### PR TITLE
Improve DenseVectorField

### DIFF
--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
@@ -35,26 +35,26 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
   }
 
   it should "not set similarity or indexOptions when index = false" in {
-    val field = DenseVectorField(name = "myfield", dims = 3, index = false, indexOptions = Some(denseVectorIndexOptions))
+    val field = DenseVectorField(name = "myfield", dims = Some(3), index = Some(false), indexOptions = Some(denseVectorIndexOptions))
     DenseVectorFieldBuilderFn.build(field).string shouldBe
       """{"type":"dense_vector","dims":3,"index":false}"""
   }
 
   it should "support indexOptions property" in {
-    val field = DenseVectorField(name = "myfield", dims = 3, index = true, indexOptions = Some(denseVectorIndexOptions))
+    val field = DenseVectorField(name = "myfield", dims = Some(3), index = Some(true), indexOptions = Some(denseVectorIndexOptions))
     DenseVectorFieldBuilderFn.build(field).string shouldBe
-      """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_hnsw","m":10,"ef_construction":100,"confidence_interval":1.0}}"""
+      """{"type":"dense_vector","dims":3,"index":true,"index_options":{"type":"int8_hnsw","m":10,"ef_construction":100,"confidence_interval":1.0}}"""
   }
 
   it should "support all index options types and only set m, efConstruction and confidenceInterval when applicable" in {
-    val field = DenseVectorField(name = "myfield", dims = 3, index = true, indexOptions = Some(denseVectorIndexOptions))
+    val field = DenseVectorField(name = "myfield", dims = Some(3), index = Some(true), indexOptions = Some(denseVectorIndexOptions))
     DenseVectorFieldBuilderFn.build(field).string shouldBe
-      """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_hnsw","m":10,"ef_construction":100,"confidence_interval":1.0}}"""
+      """{"type":"dense_vector","dims":3,"index":true,"index_options":{"type":"int8_hnsw","m":10,"ef_construction":100,"confidence_interval":1.0}}"""
     DenseVectorFieldBuilderFn.build(field.indexOptions(denseVectorIndexOptions.copy(`type` = Hnsw))).string shouldBe
-      """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"hnsw","m":10,"ef_construction":100}}"""
+      """{"type":"dense_vector","dims":3,"index":true,"index_options":{"type":"hnsw","m":10,"ef_construction":100}}"""
     DenseVectorFieldBuilderFn.build(field.indexOptions(denseVectorIndexOptions.copy(`type` = Flat))).string shouldBe
-      """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"flat"}}"""
+      """{"type":"dense_vector","dims":3,"index":true,"index_options":{"type":"flat"}}"""
     DenseVectorFieldBuilderFn.build(field.indexOptions(denseVectorIndexOptions.copy(`type` = Int8Flat))).string shouldBe
-      """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_flat","confidence_interval":1.0}}"""
+      """{"type":"dense_vector","dims":3,"index":true,"index_options":{"type":"int8_flat","confidence_interval":1.0}}"""
   }
 }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
@@ -1,13 +1,14 @@
 package com.sksamuel.elastic4s.requests.mappings
 
-import com.sksamuel.elastic4s.fields.DenseVectorField.{Hnsw, Int8Hnsw}
+import com.sksamuel.elastic4s.fields.DenseVectorField.{Flat, Hnsw, Int8Flat, Int8Hnsw}
 import com.sksamuel.elastic4s.ElasticApi
 import com.sksamuel.elastic4s.fields.{Cosine, DenseVectorField, DenseVectorIndexOptions, DotProduct, L2Norm, MaxInnerProduct}
-import com.sksamuel.elastic4s.handlers.fields.{DenseVectorFieldBuilderFn, ElasticFieldBuilderFn}
+import com.sksamuel.elastic4s.handlers.fields.{DenseVectorFieldBuilderFn}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
+  private val denseVectorIndexOptions = DenseVectorIndexOptions(Int8Hnsw, Some(10), Some(100), Some(1.0f))
 
   "A DenseVectorField" should "support dims property" in {
     val field = DenseVectorField(name = "myfield", dims = 3)
@@ -39,37 +40,21 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
       """{"type":"dense_vector","dims":3,"index":false}"""
   }
 
-  "A DenseVectorField" should "don't support a flat type of kNN algorithm for a index_options if a index property is false" in {
-    val field = DenseVectorField(
-      name = "myfield",
-      dims = 3,
-      similarity = L2Norm,
-      indexOptions = Some(DenseVectorIndexOptions(`type` = DenseVectorField.Flat))
-    )
-    val jsonStringValue = """{"type":"dense_vector","dims":3,"index":false,"similarity":"l2_norm"}"""
-    ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
+  it should "support indexOptions property" in {
+    val field = DenseVectorField(name = "myfield", dims = 3, index = true, indexOptions = Some(denseVectorIndexOptions))
+    DenseVectorFieldBuilderFn.build(field).string shouldBe
+      """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_hnsw","m":10,"ef_construction":100,"confidence_interval":1.0}}"""
   }
 
-  "A DenseVectorField" should "support a int8_flat type of kNN algorithm for a index_options if a index property is true" in {
-    val field = DenseVectorField(
-      name = "myfield",
-      dims = 3,
-      index = true,
-      similarity = L2Norm,
-      indexOptions = Some(DenseVectorIndexOptions(`type` = DenseVectorField.Int8Flat, confidenceInterval = Some(0.5d)))
-    )
-    val jsonStringValue = """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_flat","confidence_interval":0.5}}"""
-    ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
-  }
-
-  "A DenseVectorField" should "don't support a int8_flat type of kNN algorithm for a index_options if a index property  is false" in {
-    val field = DenseVectorField(
-      name = "myfield",
-      dims = 3,
-      similarity = L2Norm,
-      indexOptions = Some(DenseVectorIndexOptions(`type` = DenseVectorField.Int8Flat, confidenceInterval = Some(0.5d)))
-    )
-    val jsonStringValue = """{"type":"dense_vector","dims":3,"index":false,"similarity":"l2_norm"}"""
-    ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
+  it should "support all index options types and only set m, efConstruction and confidenceInterval when applicable" in {
+    val field = DenseVectorField(name = "myfield", dims = 3, index = true, indexOptions = Some(denseVectorIndexOptions))
+    DenseVectorFieldBuilderFn.build(field).string shouldBe
+      """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_hnsw","m":10,"ef_construction":100,"confidence_interval":1.0}}"""
+    DenseVectorFieldBuilderFn.build(field.copy(indexOptions = Some(denseVectorIndexOptions.copy(`type` = Hnsw)))).string shouldBe
+      """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"hnsw","m":10,"ef_construction":100}}"""
+    DenseVectorFieldBuilderFn.build(field.copy(indexOptions = Some(denseVectorIndexOptions.copy(`type` = Flat)))).string shouldBe
+      """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"flat"}}"""
+    DenseVectorFieldBuilderFn.build(field.copy(indexOptions = Some(denseVectorIndexOptions.copy(`type` = Int8Flat)))).string shouldBe
+      """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_flat","confidence_interval":1.0}}"""
   }
 }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
@@ -26,6 +26,12 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
       """{"type":"dense_vector","dims":3,"index":true,"similarity":"max_inner_product"}"""
   }
 
+  it should "support elementType property" in {
+    val field = DenseVectorField(name = "myfield", dims = 3).elementType("byte")
+    DenseVectorFieldBuilderFn.build(field).string shouldBe
+      """{"type":"dense_vector","element_type":"byte","dims":3,"index":false,"similarity":"l2_norm"}"""
+  }
+
   "A DenseVectorField" should "support a hnsw type of kNN algorithm for a index_options if a index property is true" in {
     val field = DenseVectorField(
       name = "myfield",

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
@@ -1,7 +1,8 @@
 package com.sksamuel.elastic4s.requests.mappings
 
-import com.sksamuel.elastic4s.{ElasticApi, JacksonSupport}
-import com.sksamuel.elastic4s.fields.{Cosine, DenseVectorField, DotProduct, FlatIndexOptions, HnswIndexOptions, Int8FlatIndexOptions, Int8HnswIndexOptions, L2Norm, MaxInnerProduct}
+import com.sksamuel.elastic4s.fields.DenseVectorField.{Hnsw, Int8Hnsw}
+import com.sksamuel.elastic4s.ElasticApi
+import com.sksamuel.elastic4s.fields.{Cosine, DenseVectorField, DenseVectorIndexOptions, DotProduct, L2Norm, MaxInnerProduct}
 import com.sksamuel.elastic4s.handlers.fields.{DenseVectorFieldBuilderFn, ElasticFieldBuilderFn}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -38,7 +39,7 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
       dims = 3,
       index = true,
       similarity = L2Norm,
-      indexOptions = Some(HnswIndexOptions(m = Some(100), efConstruction = Some(200)))
+      indexOptions = Some(DenseVectorIndexOptions(`type` = Hnsw, m = Some(100), efConstruction = Some(200)))
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"hnsw","m":100,"ef_construction":200}}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
@@ -49,7 +50,7 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
       name = "myfield",
       dims = 3,
       similarity = L2Norm,
-      indexOptions = Some(HnswIndexOptions(m = Some(100), efConstruction = Some(200)))
+      indexOptions = Some(DenseVectorIndexOptions(`type` = Hnsw, m = Some(100), efConstruction = Some(200)))
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":false,"similarity":"l2_norm"}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
@@ -61,7 +62,7 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
       dims = 3,
       index = true,
       similarity = L2Norm,
-      indexOptions = Some(Int8HnswIndexOptions(m = Some(100), efConstruction = Some(200), confidenceInterval = Some(0.5d)))
+      indexOptions = Some(DenseVectorIndexOptions(`type` = Int8Hnsw,  m = Some(100), efConstruction = Some(200), confidenceInterval = Some(0.5d)))
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_hnsw","m":100,"ef_construction":200,"confidence_interval":0.5}}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
@@ -72,7 +73,7 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
       name = "myfield",
       dims = 3,
       similarity = L2Norm,
-      indexOptions = Some(Int8HnswIndexOptions(m = Some(100), efConstruction = Some(200), confidenceInterval = Some(0.5d)))
+      indexOptions = Some(DenseVectorIndexOptions(`type` = Int8Hnsw,  m = Some(100), efConstruction = Some(200), confidenceInterval = Some(0.5d)))
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":false,"similarity":"l2_norm"}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
@@ -84,7 +85,7 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
       dims = 3,
       index = true,
       similarity = L2Norm,
-      indexOptions = Some(FlatIndexOptions())
+      indexOptions = Some(DenseVectorIndexOptions(`type` = DenseVectorField.Flat))
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"flat"}}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
@@ -95,7 +96,7 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
       name = "myfield",
       dims = 3,
       similarity = L2Norm,
-      indexOptions = Some(FlatIndexOptions())
+      indexOptions = Some(DenseVectorIndexOptions(`type` = DenseVectorField.Flat))
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":false,"similarity":"l2_norm"}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
@@ -107,7 +108,7 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
       dims = 3,
       index = true,
       similarity = L2Norm,
-      indexOptions = Some(Int8FlatIndexOptions(confidenceInterval = Some(0.5d)))
+      indexOptions = Some(DenseVectorIndexOptions(`type` = DenseVectorField.Int8Flat, confidenceInterval = Some(0.5d)))
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_flat","confidence_interval":0.5}}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
@@ -118,7 +119,7 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
       name = "myfield",
       dims = 3,
       similarity = L2Norm,
-      indexOptions = Some(Int8FlatIndexOptions(confidenceInterval = Some(0.5d)))
+      indexOptions = Some(DenseVectorIndexOptions(`type` = DenseVectorField.Int8Flat, confidenceInterval = Some(0.5d)))
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":false,"similarity":"l2_norm"}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
@@ -12,10 +12,10 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
   "A DenseVectorField" should "support dims property" in {
     val field = DenseVectorField(name = "myfield", dims = 3)
     DenseVectorFieldBuilderFn.build(field).string shouldBe
-      """{"type":"dense_vector","dims":3,"index":false,"similarity":"l2_norm"}"""
+      """{"type":"dense_vector","dims":3,"index":false}"""
   }
 
-  it should "all similarity options" in {
+  it should "support all similarity options" in {
     val field = DenseVectorField(name = "myfield", dims = 3, index = true, similarity = L2Norm)
     DenseVectorFieldBuilderFn.build(field).string shouldBe
       """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm"}"""
@@ -30,65 +30,13 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
   it should "support elementType property" in {
     val field = DenseVectorField(name = "myfield", dims = 3).elementType("byte")
     DenseVectorFieldBuilderFn.build(field).string shouldBe
-      """{"type":"dense_vector","element_type":"byte","dims":3,"index":false,"similarity":"l2_norm"}"""
+      """{"type":"dense_vector","element_type":"byte","dims":3,"index":false}"""
   }
 
-  "A DenseVectorField" should "support a hnsw type of kNN algorithm for a index_options if a index property is true" in {
-    val field = DenseVectorField(
-      name = "myfield",
-      dims = 3,
-      index = true,
-      similarity = L2Norm,
-      indexOptions = Some(DenseVectorIndexOptions(`type` = Hnsw, m = Some(100), efConstruction = Some(200)))
-    )
-    val jsonStringValue = """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"hnsw","m":100,"ef_construction":200}}"""
-    ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
-  }
-
-  "A DenseVectorField" should "don't support a hnsw type of kNN algorithm for a index_options if a index property is false" in {
-    val field = DenseVectorField(
-      name = "myfield",
-      dims = 3,
-      similarity = L2Norm,
-      indexOptions = Some(DenseVectorIndexOptions(`type` = Hnsw, m = Some(100), efConstruction = Some(200)))
-    )
-    val jsonStringValue = """{"type":"dense_vector","dims":3,"index":false,"similarity":"l2_norm"}"""
-    ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
-  }
-
-  "A DenseVectorField" should "support a int8_hnsw type of kNN algorithm for a index_options if a index property is true" in {
-    val field = DenseVectorField(
-      name = "myfield",
-      dims = 3,
-      index = true,
-      similarity = L2Norm,
-      indexOptions = Some(DenseVectorIndexOptions(`type` = Int8Hnsw,  m = Some(100), efConstruction = Some(200), confidenceInterval = Some(0.5d)))
-    )
-    val jsonStringValue = """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_hnsw","m":100,"ef_construction":200,"confidence_interval":0.5}}"""
-    ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
-  }
-
-  "A DenseVectorField" should "don't support a int8_hnsw type of kNN algorithm for a index_options if a index property is false" in {
-    val field = DenseVectorField(
-      name = "myfield",
-      dims = 3,
-      similarity = L2Norm,
-      indexOptions = Some(DenseVectorIndexOptions(`type` = Int8Hnsw,  m = Some(100), efConstruction = Some(200), confidenceInterval = Some(0.5d)))
-    )
-    val jsonStringValue = """{"type":"dense_vector","dims":3,"index":false,"similarity":"l2_norm"}"""
-    ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
-  }
-
-  "A DenseVectorField" should "support a flat type of kNN algorithm for a index_options if a index property is true" in {
-    val field = DenseVectorField(
-      name = "myfield",
-      dims = 3,
-      index = true,
-      similarity = L2Norm,
-      indexOptions = Some(DenseVectorIndexOptions(`type` = DenseVectorField.Flat))
-    )
-    val jsonStringValue = """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"flat"}}"""
-    ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
+  it should "not set similarity or indexOptions when index = false" in {
+    val field = DenseVectorField(name = "myfield", dims = 3, index = false, indexOptions = Some(denseVectorIndexOptions))
+    DenseVectorFieldBuilderFn.build(field).string shouldBe
+      """{"type":"dense_vector","dims":3,"index":false}"""
   }
 
   "A DenseVectorField" should "don't support a flat type of kNN algorithm for a index_options if a index property is false" in {

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.requests.mappings
 
 import com.sksamuel.elastic4s.{ElasticApi, JacksonSupport}
-import com.sksamuel.elastic4s.fields.{DenseVectorField, FlatIndexOptions, HnswIndexOptions, Int8FlatIndexOptions, Int8HnswIndexOptions, L2Norm}
+import com.sksamuel.elastic4s.fields.{Cosine, DenseVectorField, DotProduct, FlatIndexOptions, HnswIndexOptions, Int8FlatIndexOptions, Int8HnswIndexOptions, L2Norm, MaxInnerProduct}
 import com.sksamuel.elastic4s.handlers.fields.{DenseVectorFieldBuilderFn, ElasticFieldBuilderFn}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -12,6 +12,18 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
     val field = DenseVectorField(name = "myfield", dims = 3)
     DenseVectorFieldBuilderFn.build(field).string shouldBe
       """{"type":"dense_vector","dims":3,"index":false,"similarity":"l2_norm"}"""
+  }
+
+  it should "all similarity options" in {
+    val field = DenseVectorField(name = "myfield", dims = 3, index = true, similarity = L2Norm)
+    DenseVectorFieldBuilderFn.build(field).string shouldBe
+      """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm"}"""
+    DenseVectorFieldBuilderFn.build(field.similarity(DotProduct)).string shouldBe
+      """{"type":"dense_vector","dims":3,"index":true,"similarity":"dot_product"}"""
+    DenseVectorFieldBuilderFn.build(field.similarity(Cosine)).string shouldBe
+      """{"type":"dense_vector","dims":3,"index":true,"similarity":"cosine"}"""
+    DenseVectorFieldBuilderFn.build(field.similarity(MaxInnerProduct)).string shouldBe
+      """{"type":"dense_vector","dims":3,"index":true,"similarity":"max_inner_product"}"""
   }
 
   "A DenseVectorField" should "support a hnsw type of kNN algorithm for a index_options if a index property is true" in {

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
@@ -24,7 +24,6 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"hnsw","m":100,"ef_construction":200}}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
-    ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonStringValue)) shouldBe (field)
   }
 
   "A DenseVectorField" should "don't support a hnsw type of kNN algorithm for a index_options if a index property is false" in {
@@ -36,7 +35,6 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":false,"similarity":"l2_norm"}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
-    ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonStringValue)) shouldBe (field.copy(indexOptions = None))
   }
 
   "A DenseVectorField" should "support a int8_hnsw type of kNN algorithm for a index_options if a index property is true" in {
@@ -49,7 +47,6 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_hnsw","m":100,"ef_construction":200,"confidence_interval":0.5}}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
-    ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonStringValue)) shouldBe (field)
   }
 
   "A DenseVectorField" should "don't support a int8_hnsw type of kNN algorithm for a index_options if a index property is false" in {
@@ -61,7 +58,6 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":false,"similarity":"l2_norm"}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
-    ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonStringValue)) shouldBe (field.copy(indexOptions = None))
   }
 
   "A DenseVectorField" should "support a flat type of kNN algorithm for a index_options if a index property is true" in {
@@ -74,7 +70,6 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"flat"}}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
-    ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonStringValue)) shouldBe (field)
   }
 
   "A DenseVectorField" should "don't support a flat type of kNN algorithm for a index_options if a index property is false" in {
@@ -86,7 +81,6 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":false,"similarity":"l2_norm"}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
-    ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonStringValue)) shouldBe (field.copy(indexOptions = None))
   }
 
   "A DenseVectorField" should "support a int8_flat type of kNN algorithm for a index_options if a index property is true" in {
@@ -99,7 +93,6 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_flat","confidence_interval":0.5}}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
-    ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonStringValue)) shouldBe (field)
   }
 
   "A DenseVectorField" should "don't support a int8_flat type of kNN algorithm for a index_options if a index property  is false" in {
@@ -111,6 +104,5 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
     )
     val jsonStringValue = """{"type":"dense_vector","dims":3,"index":false,"similarity":"l2_norm"}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
-    ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonStringValue)) shouldBe (field.copy(indexOptions = None))
   }
 }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/mappings/DenseVectorFieldTest.scala
@@ -50,11 +50,11 @@ class DenseVectorFieldTest extends AnyFlatSpec with Matchers with ElasticApi {
     val field = DenseVectorField(name = "myfield", dims = 3, index = true, indexOptions = Some(denseVectorIndexOptions))
     DenseVectorFieldBuilderFn.build(field).string shouldBe
       """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_hnsw","m":10,"ef_construction":100,"confidence_interval":1.0}}"""
-    DenseVectorFieldBuilderFn.build(field.copy(indexOptions = Some(denseVectorIndexOptions.copy(`type` = Hnsw)))).string shouldBe
+    DenseVectorFieldBuilderFn.build(field.indexOptions(denseVectorIndexOptions.copy(`type` = Hnsw))).string shouldBe
       """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"hnsw","m":10,"ef_construction":100}}"""
-    DenseVectorFieldBuilderFn.build(field.copy(indexOptions = Some(denseVectorIndexOptions.copy(`type` = Flat)))).string shouldBe
+    DenseVectorFieldBuilderFn.build(field.indexOptions(denseVectorIndexOptions.copy(`type` = Flat))).string shouldBe
       """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"flat"}}"""
-    DenseVectorFieldBuilderFn.build(field.copy(indexOptions = Some(denseVectorIndexOptions.copy(`type` = Int8Flat)))).string shouldBe
+    DenseVectorFieldBuilderFn.build(field.indexOptions(denseVectorIndexOptions.copy(`type` = Int8Flat))).string shouldBe
       """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_flat","confidence_interval":1.0}}"""
   }
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
@@ -35,6 +35,8 @@ case class DenseVectorField(name: String,
   def similarity(similarity: Similarity): DenseVectorField = copy(similarity = similarity)
 
   def elementType(elementType: String): DenseVectorField = copy(elementType = Some(elementType))
+
+  def indexOptions(indexOptions: DenseVectorIndexOptions): DenseVectorField = copy(indexOptions = Some(indexOptions))
 }
 
 case class DenseVectorIndexOptions(`type`: DenseVectorField.KnnType, m: Option[Int] = None, efConstruction: Option[Int] = None, confidenceInterval: Option[Double] = None)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
@@ -39,7 +39,9 @@ case object DotProduct extends Similarity { val name = "dot_product" }
 case object Cosine extends Similarity { val name = "cosine" }
 case object MaxInnerProduct extends Similarity { val name = "max_inner_product" }
 
-case class DenseVectorIndexOptions(`type`: DenseVectorField.KnnType, m: Option[Int] = None, efConstruction: Option[Int] = None, confidenceInterval: Option[Double] = None)
+case class DenseVectorIndexOptions(`type`: DenseVectorField.KnnType, m: Option[Int] = None, efConstruction: Option[Int] = None, confidenceInterval: Option[Float] = None) {
+
+}
 
 case class DenseVectorField(name: String,
                             elementType: Option[String] = None,

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
@@ -10,33 +10,48 @@ object DenseVectorField {
   case object Int8Hnsw extends KnnType { val name = "int8_hnsw" }
   case object Flat extends KnnType { val name = "flat" }
   case object Int8Flat extends KnnType { val name = "int8_flat" }
+
+  @deprecated("Use the new apply method", "8.14.0")
+  def apply(name: String,
+            dims: Int): DenseVectorField =
+    DenseVectorField(name, None, Some(dims), Some(false), Some(L2Norm))
+
+  @deprecated("Use the new apply method", "8.14.0")
+  def apply(name: String,
+            dims: Int,
+            index: Boolean): DenseVectorField =
+    DenseVectorField(name, None, Some(dims), Some(index), Some(L2Norm))
+
+  @deprecated("Use the new apply method", "8.14.0")
+  def apply(name: String,
+            dims: Int,
+            index: Boolean,
+            similarity: Similarity): DenseVectorField =
+    DenseVectorField(name, None, Some(dims), Some(index), Some(similarity))
 }
 
 sealed trait Similarity {
   def name: String
 }
+
 case object L2Norm extends Similarity { val name = "l2_norm" }
 case object DotProduct extends Similarity { val name = "dot_product" }
 case object Cosine extends Similarity { val name = "cosine" }
 case object MaxInnerProduct extends Similarity { val name = "max_inner_product" }
 
+case class DenseVectorIndexOptions(`type`: DenseVectorField.KnnType, m: Option[Int] = None, efConstruction: Option[Int] = None, confidenceInterval: Option[Double] = None)
+
 case class DenseVectorField(name: String,
-                            dims: Int,
-                            index: Boolean = false,
-                            similarity: Similarity = L2Norm,
-                            indexOptions: Option[DenseVectorIndexOptions] = None,
-                            elementType: Option[String] = None) extends ElasticField {
-  override def `type`: String  = DenseVectorField.`type`
-
-  def dims(dims: Int): DenseVectorField = copy(dims = dims)
-
-  def index(index: Boolean): DenseVectorField = copy(index = index)
-
-  def similarity(similarity: Similarity): DenseVectorField = copy(similarity = similarity)
+                            elementType: Option[String] = None,
+                            dims: Option[Int] = None,
+                            index: Option[Boolean] = None,
+                            similarity: Option[Similarity] = None,
+                            indexOptions: Option[DenseVectorIndexOptions] = None) extends ElasticField {
+  override def `type`: String = DenseVectorField.`type`
 
   def elementType(elementType: String): DenseVectorField = copy(elementType = Some(elementType))
-
+  def dims(dims: Int): DenseVectorField = copy(dims = Some(dims))
+  def index(index: Boolean): DenseVectorField = copy(index = Some(index))
+  def similarity(similarity: Similarity): DenseVectorField = copy(similarity = Some(similarity))
   def indexOptions(indexOptions: DenseVectorIndexOptions): DenseVectorField = copy(indexOptions = Some(indexOptions))
 }
-
-case class DenseVectorIndexOptions(`type`: DenseVectorField.KnnType, m: Option[Int] = None, efConstruction: Option[Int] = None, confidenceInterval: Option[Double] = None)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
@@ -2,7 +2,16 @@ package com.sksamuel.elastic4s.fields
 
 object DenseVectorField {
   val `type`: String = "dense_vector"
+
+  sealed trait KnnType {
+    def name: String
+  }
+  case object Hnsw extends KnnType { val name = "hnsw" }
+  case object Int8Hnsw extends KnnType { val name = "int8_hnsw" }
+  case object Flat extends KnnType { val name = "flat" }
+  case object Int8Flat extends KnnType { val name = "int8_flat" }
 }
+
 sealed trait Similarity {
   def name: String
 }
@@ -28,20 +37,4 @@ case class DenseVectorField(name: String,
   def elementType(elementType: String): DenseVectorField = copy(elementType = Some(elementType))
 }
 
-sealed trait DenseVectorIndexOptions {
-  def `type`: String
-}
-case class HnswIndexOptions(m: Option[Int] = None, efConstruction: Option[Int] = None) extends DenseVectorIndexOptions {
-  val `type`: String = "hnsw"
-}
-case class Int8HnswIndexOptions(m: Option[Int] = None,
-                                efConstruction: Option[Int] = None,
-                                confidenceInterval: Option[Double] = None) extends DenseVectorIndexOptions {
-  val `type`: String = "int8_hnsw"
-}
-case class FlatIndexOptions() extends DenseVectorIndexOptions {
-  val `type`: String = "flat"
-}
-case class Int8FlatIndexOptions(confidenceInterval: Option[Double] = None) extends DenseVectorIndexOptions {
-  val `type`: String = "int8_flat"
-}
+case class DenseVectorIndexOptions(`type`: DenseVectorField.KnnType, m: Option[Int] = None, efConstruction: Option[Int] = None, confidenceInterval: Option[Double] = None)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
@@ -15,10 +15,13 @@ case class DenseVectorField(name: String,
                             dims: Int,
                             index: Boolean = false,
                             similarity: Similarity = L2Norm,
-                            indexOptions: Option[DenseVectorIndexOptions] = None) extends ElasticField {
+                            indexOptions: Option[DenseVectorIndexOptions] = None,
+                            elementType: Option[String] = None) extends ElasticField {
   override def `type`: String  = DenseVectorField.`type`
 
   def similarity(similarity: Similarity): DenseVectorField = copy(similarity = similarity)
+
+  def elementType(elementType: String): DenseVectorField = copy(elementType = Some(elementType))
 }
 
 sealed trait DenseVectorIndexOptions {

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
@@ -9,6 +9,7 @@ sealed trait Similarity {
 case object L2Norm extends Similarity { val name = "l2_norm" }
 case object DotProduct extends Similarity { val name = "dot_product" }
 case object Cosine extends Similarity { val name = "cosine" }
+case object MaxInnerProduct extends Similarity { val name = "max_inner_product" }
 
 case class DenseVectorField(name: String,
                             dims: Int,
@@ -16,6 +17,8 @@ case class DenseVectorField(name: String,
                             similarity: Similarity = L2Norm,
                             indexOptions: Option[DenseVectorIndexOptions] = None) extends ElasticField {
   override def `type`: String  = DenseVectorField.`type`
+
+  def similarity(similarity: Similarity): DenseVectorField = copy(similarity = similarity)
 }
 
 sealed trait DenseVectorIndexOptions {

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DenseVectorField.scala
@@ -19,6 +19,10 @@ case class DenseVectorField(name: String,
                             elementType: Option[String] = None) extends ElasticField {
   override def `type`: String  = DenseVectorField.`type`
 
+  def dims(dims: Int): DenseVectorField = copy(dims = dims)
+
+  def index(index: Boolean): DenseVectorField = copy(index = index)
+
   def similarity(similarity: Similarity): DenseVectorField = copy(similarity = similarity)
 
   def elementType(elementType: String): DenseVectorField = copy(elementType = Some(elementType))

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DenseVectorFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DenseVectorFieldBuilderFn.scala
@@ -24,13 +24,15 @@ object DenseVectorFieldBuilderFn {
     name,
     values("dims").asInstanceOf[Int],
     values("index").asInstanceOf[Boolean],
-    indexOptions = values.get("index_options").map(_.asInstanceOf[Map[String, Any]]).map(getIndexOptions)
+    indexOptions = values.get("index_options").map(_.asInstanceOf[Map[String, Any]]).map(getIndexOptions),
+    elementType = values.get("element_type").map(_.asInstanceOf[String])
   )
 
   def build(field: DenseVectorField): XContentBuilder = {
 
     val builder = XContentFactory.jsonBuilder()
     builder.field("type", field.`type`)
+    field.elementType.foreach(builder.field("element_type", _))
     builder.field("dims", field.dims)
     builder.field("index", field.index)
     builder.field("similarity", field.similarity.name)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DenseVectorFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DenseVectorFieldBuilderFn.scala
@@ -45,8 +45,8 @@ object DenseVectorFieldBuilderFn {
     field.elementType.foreach(builder.field("element_type", _))
     builder.field("dims", field.dims)
     builder.field("index", field.index)
+    if (field.index) {
     builder.field("similarity", field.similarity.name)
-    if (field.index)
       field.indexOptions.foreach { options =>
         builder.startObject("index_options")
         builder.field("type", options.`type`.name)
@@ -55,6 +55,7 @@ object DenseVectorFieldBuilderFn {
         if (Seq(Int8Hnsw, Int8Flat).contains(options.`type`)) options.confidenceInterval.foreach(builder.field("confidence_interval", _))
         builder.endObject()
       }
+    }
     builder.endObject()
   }
 }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DenseVectorFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DenseVectorFieldBuilderFn.scala
@@ -1,23 +1,33 @@
 package com.sksamuel.elastic4s.handlers.fields
 
-import com.sksamuel.elastic4s.fields.{DenseVectorField, DenseVectorIndexOptions, FlatIndexOptions, HnswIndexOptions, Int8FlatIndexOptions, Int8HnswIndexOptions}
+import com.sksamuel.elastic4s.fields.DenseVectorField.{Hnsw, Int8Flat, Int8Hnsw}
+import com.sksamuel.elastic4s.fields.{DenseVectorField, DenseVectorIndexOptions}
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object DenseVectorFieldBuilderFn {
 
-  private def getIndexOptions(values: Map[String, Any]): DenseVectorIndexOptions=
+  private def getIndexOptions(values: Map[String, Any]): DenseVectorIndexOptions =
     values("type").asInstanceOf[String] match {
-      case "hnsw" => HnswIndexOptions(
+      case "hnsw" => DenseVectorIndexOptions(
+        DenseVectorField.Hnsw,
         values.get("m").map(_.asInstanceOf[Int]),
         values.get("ef_construction").map(_.asInstanceOf[Int])
       )
-      case "int8_hnsw" => Int8HnswIndexOptions(
+      case "int8_hnsw" => DenseVectorIndexOptions(
+        DenseVectorField.Int8Hnsw,
         values.get("m").map(_.asInstanceOf[Int]),
         values.get("ef_construction").map(_.asInstanceOf[Int]),
         values.get("confidence_interval").map(_.asInstanceOf[Double])
       )
-      case "flat" => FlatIndexOptions()
-      case "int8_flat" => Int8FlatIndexOptions(values.get("confidence_interval").map(_.asInstanceOf[Double]))
+      case "flat" => DenseVectorIndexOptions(
+        DenseVectorField.Flat
+      )
+      case "int8_flat" => DenseVectorIndexOptions(
+        DenseVectorField.Int8Flat,
+        None,
+        None,
+        values.get("confidence_interval").map(_.asInstanceOf[Double])
+      )
     }
 
   def toField(name: String, values: Map[String, Any]): DenseVectorField = DenseVectorField(
@@ -36,23 +46,15 @@ object DenseVectorFieldBuilderFn {
     builder.field("dims", field.dims)
     builder.field("index", field.index)
     builder.field("similarity", field.similarity.name)
-    field.indexOptions.filter(_ => field.index).foreach { options =>
-      builder.startObject("index_options")
-      builder.field("type", options.`type`)
-      options match {
-        case HnswIndexOptions(m, efConstruction) =>
-          m.foreach(builder.field("m", _))
-          efConstruction.foreach(builder.field("ef_construction", _))
-        case Int8HnswIndexOptions(m, efConstruction, confidenceInterval) =>
-          m.foreach(builder.field("m", _))
-          efConstruction.foreach(builder.field("ef_construction", _))
-          confidenceInterval.foreach(builder.field("confidence_interval", _))
-        case FlatIndexOptions() => ()
-        case Int8FlatIndexOptions(confidenceInterval) =>
-          confidenceInterval.foreach(builder.field("confidence_interval", _))
+    if (field.index)
+      field.indexOptions.foreach { options =>
+        builder.startObject("index_options")
+        builder.field("type", options.`type`.name)
+        if (Seq(Hnsw, Int8Hnsw).contains(options.`type`)) options.m.foreach(builder.field("m", _))
+        if (Seq(Hnsw, Int8Hnsw).contains(options.`type`)) options.efConstruction.foreach(builder.field("ef_construction", _))
+        if (Seq(Int8Hnsw, Int8Flat).contains(options.`type`)) options.confidenceInterval.foreach(builder.field("confidence_interval", _))
+        builder.endObject()
       }
-      builder.endObject()
-    }
     builder.endObject()
   }
 }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DenseVectorFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/DenseVectorFieldBuilderFn.scala
@@ -23,7 +23,7 @@ object DenseVectorFieldBuilderFn {
         DenseVectorField.Int8Hnsw,
         values.get("m").map(_.asInstanceOf[Int]),
         values.get("ef_construction").map(_.asInstanceOf[Int]),
-        values.get("confidence_interval").map(_.asInstanceOf[Double])
+        values.get("confidence_interval").map(d => d.asInstanceOf[Double].toFloat)
       )
       case "flat" => DenseVectorIndexOptions(
         DenseVectorField.Flat
@@ -32,7 +32,7 @@ object DenseVectorFieldBuilderFn {
         DenseVectorField.Int8Flat,
         None,
         None,
-        values.get("confidence_interval").map(_.asInstanceOf[Double])
+        values.get("confidence_interval").map(d => d.asInstanceOf[Double].toFloat)
       )
     }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/ElasticFieldBuilderFnTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/ElasticFieldBuilderFnTest.scala
@@ -113,15 +113,22 @@ class ElasticFieldBuilderFnTest extends AnyWordSpec with Matchers {
     }
 
     "support DenseVectorField" in {
-      val field = DenseVectorField("dense_vector_field", dims = 3, index = true, indexOptions = Some(DenseVectorIndexOptions(DenseVectorField.Flat)), elementType = Some("byte"))
-      val jsonString = """{"type":"dense_vector","element_type":"byte","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"flat"}}"""
+      val field = DenseVectorField("dense_vector_field", elementType = Some("byte"), dims = Some(3), index = Some(true), indexOptions = Some(DenseVectorIndexOptions(DenseVectorField.Flat)))
+      val jsonString = """{"type":"dense_vector","element_type":"byte","dims":3,"index":true,"index_options":{"type":"flat"}}"""
+      ElasticFieldBuilderFn(field).string shouldBe jsonString
+      ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
+    }
+
+    "support DenseVectorField with similarity" in {
+      val field = DenseVectorField("dense_vector_field", elementType = Some("byte"), dims = Some(3), index = Some(true), similarity = Some(MaxInnerProduct))
+      val jsonString = """{"type":"dense_vector","element_type":"byte","dims":3,"index":true,"similarity":"max_inner_product"}"""
       ElasticFieldBuilderFn(field).string shouldBe jsonString
       ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
     }
 
     "support DenseVectorField with all index options" in {
-      val field = DenseVectorField("dense_vector_field", dims = 3, index = true, indexOptions = Some(DenseVectorIndexOptions(DenseVectorField.Int8Hnsw, Some(100), Some(200), Some(0.5f))), elementType = Some("byte"))
-      val jsonString = """{"type":"dense_vector","element_type":"byte","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_hnsw","m":100,"ef_construction":200,"confidence_interval":0.5}}"""
+      val field = DenseVectorField("dense_vector_field", elementType = Some("byte"), dims = Some(3), index = Some(true), indexOptions = Some(DenseVectorIndexOptions(DenseVectorField.Int8Hnsw, Some(100), Some(200), Some(0.5f))))
+      val jsonString = """{"type":"dense_vector","element_type":"byte","dims":3,"index":true,"index_options":{"type":"int8_hnsw","m":100,"ef_construction":200,"confidence_interval":0.5}}"""
       ElasticFieldBuilderFn(field).string shouldBe jsonString
       ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
     }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/ElasticFieldBuilderFnTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/ElasticFieldBuilderFnTest.scala
@@ -113,8 +113,15 @@ class ElasticFieldBuilderFnTest extends AnyWordSpec with Matchers {
     }
 
     "support DenseVectorField" in {
-      val field = DenseVectorField("dense_vector_field", dims = 3, index = true, indexOptions = Some(FlatIndexOptions()), elementType = Some("byte"))
+      val field = DenseVectorField("dense_vector_field", dims = 3, index = true, indexOptions = Some(DenseVectorIndexOptions(DenseVectorField.Flat)), elementType = Some("byte"))
       val jsonString = """{"type":"dense_vector","element_type":"byte","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"flat"}}"""
+      ElasticFieldBuilderFn(field).string shouldBe jsonString
+      ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
+    }
+
+    "support DenseVectorField with all index options" in {
+      val field = DenseVectorField("dense_vector_field", dims = 3, index = true, indexOptions = Some(DenseVectorIndexOptions(DenseVectorField.Int8Hnsw, Some(100), Some(200), Some(0.5f))), elementType = Some("byte"))
+      val jsonString = """{"type":"dense_vector","element_type":"byte","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"int8_hnsw","m":100,"ef_construction":200,"confidence_interval":0.5}}"""
       ElasticFieldBuilderFn(field).string shouldBe jsonString
       ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
     }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/ElasticFieldBuilderFnTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/ElasticFieldBuilderFnTest.scala
@@ -112,6 +112,11 @@ class ElasticFieldBuilderFnTest extends AnyWordSpec with Matchers {
       ElasticFieldBuilderFn.construct(fieldSet.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe(fieldSet)
     }
 
+    "support DenseVectorField" in {
+      val field = DenseVectorField("dense_vector_field", dims = 3, index = true, indexOptions = Some(FlatIndexOptions()))
+      val jsonString = """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"flat"}}"""
+      ElasticFieldBuilderFn(field).string shouldBe jsonString
+      ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
+    }
   }
-
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/ElasticFieldBuilderFnTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/ElasticFieldBuilderFnTest.scala
@@ -113,8 +113,8 @@ class ElasticFieldBuilderFnTest extends AnyWordSpec with Matchers {
     }
 
     "support DenseVectorField" in {
-      val field = DenseVectorField("dense_vector_field", dims = 3, index = true, indexOptions = Some(FlatIndexOptions()))
-      val jsonString = """{"type":"dense_vector","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"flat"}}"""
+      val field = DenseVectorField("dense_vector_field", dims = 3, index = true, indexOptions = Some(FlatIndexOptions()), elementType = Some("byte"))
+      val jsonString = """{"type":"dense_vector","element_type":"byte","dims":3,"index":true,"similarity":"l2_norm","index_options":{"type":"flat"}}"""
       ElasticFieldBuilderFn(field).string shouldBe jsonString
       ElasticFieldBuilderFn.construct(field.name, JacksonSupport.mapper.readValue[Map[String, Any]](jsonString)) shouldBe field
     }


### PR DESCRIPTION
Applying this PR will improve DenseVectorField, among which:
- add element_type parameter
- add max_inner_product similarity metric
- introduce new apply method with proper defaults (following the documentation)
- not set similarity if index is set to false