### PR TITLE
Support automatic slicing using constants

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/common/Slices.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/common/Slices.scala
@@ -1,6 +1,0 @@
-package com.sksamuel.elastic4s.requests.common
-
-sealed trait Slices
-
-case object AutoSlices extends Slices
-case class NumericSlices(slices: Int) extends Slices

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/common/Slicing.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/common/Slicing.scala
@@ -1,0 +1,6 @@
+package com.sksamuel.elastic4s.requests.common
+
+object Slicing {
+  val AutoSlices = 0
+  val AutoSlicesValue = "auto"
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/delete/DeleteByQueryRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/delete/DeleteByQueryRequest.scala
@@ -2,9 +2,8 @@ package com.sksamuel.elastic4s.requests.delete
 
 import com.sksamuel.elastic4s.Indexes
 import com.sksamuel.elastic4s.ext.OptionImplicits._
-import com.sksamuel.elastic4s.requests.common.{RefreshPolicy, Slice}
+import com.sksamuel.elastic4s.requests.common.{RefreshPolicy, Slice, Slicing}
 import com.sksamuel.elastic4s.requests.searches.queries.Query
-
 import scala.concurrent.duration.FiniteDuration
 
 case class DeleteByQueryRequest(indexes: Indexes,
@@ -56,6 +55,7 @@ case class DeleteByQueryRequest(indexes: Indexes,
     copy(shouldStoreResult = shouldStoreResult.some)
 
   def slices(slices: Int): DeleteByQueryRequest = copy(slices = slices.some)
+  def automaticSlicing(): DeleteByQueryRequest = copy(slices = Some(Slicing.AutoSlices))
 
   def slice(slice: Slice): DeleteByQueryRequest = copy(slice = slice.some)
 

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/reindex/ReindexRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/reindex/ReindexRequest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.requests.reindex
 
 import com.sksamuel.elastic4s.ext.OptionImplicits._
-import com.sksamuel.elastic4s.requests.common.{RefreshPolicy, Slice, VersionType}
+import com.sksamuel.elastic4s.requests.common.{RefreshPolicy, Slice, Slicing, VersionType}
 import com.sksamuel.elastic4s.requests.script.Script
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.{Index, Indexes}
@@ -74,6 +74,7 @@ case class ReindexRequest(sourceIndexes: Indexes,
   def createOnly(createOnly: Boolean): ReindexRequest = copy(createOnly = createOnly.some)
   def slice(slice: Slice): ReindexRequest = copy(slice = slice.some)
   def slices(slices: Int): ReindexRequest = copy(slices = slices.some)
+  def automaticSlicing(): ReindexRequest = copy(slices = Some(Slicing.AutoSlices))
 
   def versionType(versionType: String): ReindexRequest = this.versionType(VersionType.valueOf(versionType))
   def versionType(versionType: VersionType): ReindexRequest = copy(versionType = versionType.some)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryAsyncRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryAsyncRequest.scala
@@ -2,10 +2,9 @@ package com.sksamuel.elastic4s.requests.update
 
 import com.sksamuel.elastic4s.Indexes
 import com.sksamuel.elastic4s.ext.OptionImplicits._
-import com.sksamuel.elastic4s.requests.common.{AutoSlices, NumericSlices, RefreshPolicy, Slice, Slices}
+import com.sksamuel.elastic4s.requests.common.{RefreshPolicy, Slice, Slicing}
 import com.sksamuel.elastic4s.requests.script.Script
 import com.sksamuel.elastic4s.requests.searches.queries.Query
-
 import scala.concurrent.duration.FiniteDuration
 
 case class UpdateByQueryAsyncRequest(indexes: Indexes,
@@ -20,12 +19,11 @@ case class UpdateByQueryAsyncRequest(indexes: Indexes,
                                      retryBackoffInitialTime: Option[FiniteDuration] = None,
                                      scroll: Option[String] = None,
                                      scrollSize: Option[Int] = None,
-                                     slices: Option[Slices] = None,
+                                     slices: Option[Int] = None,
                                      slice: Option[Slice] = None,
                                      timeout: Option[FiniteDuration] = None,
                                      shouldStoreResult: Option[Boolean] = None,
                                      size: Option[Int] = None) extends BaseUpdateByQueryRequest {
-
   def proceedOnConflicts(proceedOnConflicts: Boolean): UpdateByQueryAsyncRequest =
     copy(proceedOnConflicts = proceedOnConflicts.some)
 
@@ -40,8 +38,8 @@ case class UpdateByQueryAsyncRequest(indexes: Indexes,
 
   def scrollSize(scrollSize: Int): UpdateByQueryAsyncRequest = copy(scrollSize = scrollSize.some)
   def slice(slice: Slice): UpdateByQueryAsyncRequest = copy(slice = slice.some)
-  def slices(slices: Int): UpdateByQueryAsyncRequest = copy(slices = Some(NumericSlices(slices)))
-  def slicesAuto(): UpdateByQueryAsyncRequest = copy(slices = Some(AutoSlices))
+  def slices(slices: Int): UpdateByQueryAsyncRequest = copy(slices = slices.some)
+  def automaticSlicing(): UpdateByQueryAsyncRequest = copy(slices = Some(Slicing.AutoSlices))
 
   def requestsPerSecond(requestsPerSecond: Float): UpdateByQueryAsyncRequest =
     copy(requestsPerSecond = requestsPerSecond.some)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryRequest.scala
@@ -1,7 +1,7 @@
 package com.sksamuel.elastic4s.requests.update
 
 import com.sksamuel.elastic4s.Indexes
-import com.sksamuel.elastic4s.requests.common.{ AutoSlices, NumericSlices, RefreshPolicy, Slice, Slices}
+import com.sksamuel.elastic4s.requests.common.{RefreshPolicy, Slice, Slicing}
 import com.sksamuel.elastic4s.requests.script.Script
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.ext.OptionImplicits._
@@ -33,7 +33,7 @@ trait BaseUpdateByQueryRequest {
 
   val scrollSize: Option[Int]
 
-  val slices: Option[Slices]
+  val slices: Option[Int]
 
   val slice: Option[Slice]
 
@@ -59,7 +59,7 @@ case class UpdateByQueryRequest(indexes: Indexes,
                                 retryBackoffInitialTime: Option[FiniteDuration] = None,
                                 scroll: Option[String] = None,
                                 scrollSize: Option[Int] = None,
-                                slices: Option[Slices] = None,
+                                slices: Option[Int] = None,
                                 slice: Option[Slice] = None,
                                 timeout: Option[FiniteDuration] = None,
                                 shouldStoreResult: Option[Boolean] = None,
@@ -79,8 +79,8 @@ case class UpdateByQueryRequest(indexes: Indexes,
 
   def scrollSize(scrollSize: Int): UpdateByQueryRequest = copy(scrollSize = scrollSize.some)
   def slice(slice: Slice): UpdateByQueryRequest = copy(slice = slice.some)
-  def slices(slices: Int): UpdateByQueryRequest = copy(slices = Some(NumericSlices(slices)))
-  def slicesAuto(): UpdateByQueryRequest = copy(slices = Some(AutoSlices))
+  def slices(slices: Int): UpdateByQueryRequest = copy(slices = slices.some)
+  def automaticSlicing(): UpdateByQueryRequest = copy(slices = Some(Slicing.AutoSlices))
 
   def requestsPerSecond(requestsPerSecond: Float): UpdateByQueryRequest =
     copy(requestsPerSecond = requestsPerSecond.some)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/delete/DeleteHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/delete/DeleteHandlers.scala
@@ -4,7 +4,7 @@ import com.sksamuel.elastic4s.ext.OptionImplicits.RichOption
 import com.sksamuel.elastic4s.handlers.{ElasticErrorParser, VersionTypeHttpString}
 import com.sksamuel.elastic4s.handlers.searches.queries.QueryBuilderFn
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
-import com.sksamuel.elastic4s.requests.common.RefreshPolicyHttpValue
+import com.sksamuel.elastic4s.requests.common.{RefreshPolicyHttpValue, Slicing}
 import com.sksamuel.elastic4s.requests.delete.{DeleteByIdRequest, DeleteByQueryRequest, DeleteByQueryResponse, DeleteResponse}
 import com.sksamuel.elastic4s.requests.task.CreateTaskResponse
 import com.sksamuel.elastic4s.{ElasticError, ElasticRequest, ElasticUrlEncoder, Handler, HttpEntity, HttpResponse, ResponseHandler}
@@ -56,9 +56,10 @@ trait DeleteHandlers {
       request.maxDocs.map(_.toString).foreach(params.put("max_docs", _))
       request.waitForActiveShards.map(_.toString).foreach(params.put("wait_for_active_shards", _))
       request.waitForCompletion.map(_.toString).foreach(params.put("wait_for_completion", _))
-      request.slices.map(_.toString).foreach(params.put("slices", _))
+      request.slices.foreach(s =>
+        if (s == Slicing.AutoSlices) params.put("slices", Slicing.AutoSlicesValue) else params.put("slices", s.toString)
+      )
       request.ignoreUnavailable.map(_.toString).foreach(params.put("ignore_unavailable", _))
-
 
       val body = DeleteByQueryBodyFn(request)
       logger.debug(s"Delete by query ${body.string}")

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/update/UpdateHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/update/UpdateHandlers.scala
@@ -6,7 +6,7 @@ import com.sksamuel.elastic4s.handlers.common.FetchSourceContextQueryParameterFn
 import com.sksamuel.elastic4s.handlers.script.ScriptBuilderFn
 import com.sksamuel.elastic4s.handlers.searches.queries
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
-import com.sksamuel.elastic4s.requests.common.{AutoSlices, NumericSlices, RefreshPolicyHttpValue}
+import com.sksamuel.elastic4s.requests.common.{RefreshPolicyHttpValue, Slicing}
 import com.sksamuel.elastic4s.requests.task.GetTask
 import com.sksamuel.elastic4s.requests.update.{BaseUpdateByQueryRequest, UpdateByQueryAsyncRequest, UpdateByQueryAsyncResponse, UpdateByQueryRequest, UpdateByQueryResponse, UpdateByQueryTask, UpdateRequest, UpdateResponse}
 import com.sksamuel.elastic4s.{BulkIndexByScrollFailure, ElasticError, ElasticRequest, ElasticUrlEncoder, Handler, HttpEntity, HttpResponse, ResponseHandler}
@@ -87,10 +87,9 @@ trait UpdateHandlers {
       request.scrollSize.foreach(params.put("scroll_size", _))
       request.waitForActiveShards.foreach(params.put("wait_for_active_shards", _))
       request.waitForCompletion.foreach(params.put("wait_for_completion", _))
-      request.slices.foreach {
-        case AutoSlices            => params.put("slices", "auto")
-        case NumericSlices(slices) => params.put("slices", slices)
-      }
+      request.slices.foreach(s =>
+        if (s == Slicing.AutoSlices) params.put("slices", Slicing.AutoSlicesValue) else params.put("slices", s)
+      )
 
       val body = UpdateByQueryBodyFn(request)
       logger.debug(s"Update by query ${body.string}")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/reindex/ReindexTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/reindex/ReindexTest.scala
@@ -60,6 +60,18 @@ class ReindexTest extends AnyWordSpec with Matchers with DockerTests {
         search("reindextarget")
       }.await.result.size shouldBe 3
     }
+    "support automatic slicing" in {
+      deleteIdx("reindextarget")
+      createIdx("reindextarget")
+
+      client.execute {
+        reindex("reindex", "reindextarget").automaticSlicing().refresh(RefreshPolicy.IMMEDIATE)
+      }.await.result.left.get.created shouldBe 3
+
+      client.execute {
+        search("reindextarget")
+      }.await.result.size shouldBe 3
+    }
     "support slice parameter" in {
 
       deleteIdx("reindextarget")

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryTest.scala
@@ -62,16 +62,16 @@ class UpdateByQueryTest
     }.await.result.count shouldBe 3
   }
 
-  it should "support slices auto" in {
+  it should "support automatic slicing" in {
     client.execute {
-      updateByQuery("pop", matchAllQuery()).script(script("ctx._source.foo = 'd'").lang("painless")).slicesAuto().refresh(RefreshPolicy.IMMEDIATE)
+      updateByQuery("pop", matchAllQuery()).script(script("ctx._source.foo = 'd'").lang("painless")).automaticSlicing().refresh(RefreshPolicy.IMMEDIATE)
     }.await.result.updated shouldBe 3
 
     client.execute {
       count("pop").query(termQuery("foo", "d"))
     }.await.result.count shouldBe 3
   }
-  
+
   it should "support RefreshPolicy.NONE" in {
     client.execute {
       updateByQuery("pop", matchAllQuery()).script(script("ctx._source.foo = 'c'").lang("painless")).refresh(RefreshPolicy.NONE)


### PR DESCRIPTION
for UpdateByQuery, Reindex and DeleteByQuery. This way we don't have to change the signature of the case class at all. I took the inspiration from how it works in Elasticsearch itself (https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/reindex/AbstractBulkByScrollRequest.java#L39).