### PR TITLE
Replace deprecated AsyncHttpClientFutureBackend

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -302,7 +302,7 @@ lazy val clientsttp = (project in file("elastic4s-client-sttp"))
   .dependsOn(core, testkit % "test")
   .settings(name := "elastic4s-client-sttp")
   .settings(scala3Settings)
-  .settings(libraryDependencies ++= Seq(sttp, asyncHttpClientBackendFuture))
+  .settings(libraryDependencies ++= Seq(sttp))
 
 lazy val clientakka = (project in file("elastic4s-client-akka"))
   .dependsOn(core, testkit % "test")

--- a/elastic4s-client-sttp/src/main/scala/com/sksamuel/elastic4s/sttp/SttpRequestHttpClient.scala
+++ b/elastic4s-client-sttp/src/main/scala/com/sksamuel/elastic4s/sttp/SttpRequestHttpClient.scala
@@ -10,7 +10,6 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.io.Source
 import scala.util.{Failure, Success}
 import sttp.client3._
-import sttp.client3.asynchttpclient.future.AsyncHttpClientFutureBackend
 import sttp.model.Uri
 import sttp.model.Uri.{PathSegments, QuerySegment}
 
@@ -94,7 +93,7 @@ class SttpRequestHttpClient(nodeEndpoint: ElasticNodeEndpoint)(
 object SttpRequestHttpClient {
 
   private def defaultEc: ExecutionContext = ExecutionContext.global
-  private def defaultSttpBackend: SttpBackend[Future, Any] = AsyncHttpClientFutureBackend()
+  private def defaultSttpBackend: SttpBackend[Future, Any] = HttpClientFutureBackend()
 
   /** Instantiate an [[SttpRequestHttpClient]] with reasonable defaults for the implicit parameters. */
   def apply(nodeEndpoint: ElasticNodeEndpoint): SttpRequestHttpClient = new SttpRequestHttpClient(nodeEndpoint)(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -61,7 +61,6 @@ object Dependencies {
   lazy val akkaActor                    = "com.typesafe.akka"             %% "akka-actor"                       % AkkaVersion
   lazy val akkaHTTP                     = "com.typesafe.akka"             %% "akka-http"                        % AkkaHttpVersion
   lazy val akkaStream                   = "com.typesafe.akka"             %% "akka-stream"                      % AkkaVersion
-  lazy val asyncHttpClientBackendFuture = "com.softwaremill.sttp.client3" %% "async-http-client-backend-future" % SttpVersion
   lazy val cats                         = "org.typelevel"                 %% "cats-effect"                      % CatsEffectVersion
   lazy val cats2                        = "org.typelevel"                 %% "cats-effect"                      % CatsEffect2Version
   lazy val elasticsearchRestClient      = "org.elasticsearch.client"       % "elasticsearch-rest-client"        % ElasticsearchVersion


### PR DESCRIPTION
The async-http backend is deprecated (https://github.com/softwaremill/sttp/blob/9c66b3c85d666411d492dcb642efa0b0102941e9/docs/resilience.md?plain=1#L35) and pulls in a transitive vulnerable dependency (Netty 4.1.60.Final), so I think we should remove it.