### PR TITLE
Rank feature query function typing fixes

### DIFF
--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/RankFeatureQueryBodyFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/RankFeatureQueryBodyFnTest.scala
@@ -25,7 +25,7 @@ class RankFeatureQueryBodyFnTest extends AnyFunSuite with Matchers with GivenWhe
       |      "field": "pagerank",
       |      "boost": 0.5,
       |      "sigmoid": {
-      |         "pivot": 7,
+      |         "pivot": 7.0,
       |         "exponent": 0.6
       |      }
       |   }
@@ -50,7 +50,7 @@ class RankFeatureQueryBodyFnTest extends AnyFunSuite with Matchers with GivenWhe
         |   "rank_feature":{
         |      "field": "pagerank",
         |      "log": {
-        |          "scaling_factor": 3
+        |          "scaling_factor": 3.0
         |      }
         |   }
         |}
@@ -75,7 +75,7 @@ class RankFeatureQueryBodyFnTest extends AnyFunSuite with Matchers with GivenWhe
         |   "rank_feature":{
         |      "field": "pagerank",
         |      "saturation": {
-        |          "pivot": 2
+        |          "pivot": 2.0
         |      }
         |   }
         |}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/RankFeatureQuery.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/RankFeatureQuery.scala
@@ -26,8 +26,8 @@ case class RankFeatureQuery(field: String,
 }
 
 object RankFeatureQuery {
-  case class Saturation(pivot: Option[Int])
-  case class Log(scalingFactor: Int)
-  case class Sigmoid(pivot: Int, exponent: Double)
+  case class Saturation(pivot: Option[Float])
+  case class Log(scalingFactor: Float)
+  case class Sigmoid(pivot: Float, exponent: Double)
   case class Linear()
 }

--- a/elastic4s-tests/src/test/resources/json/search/search_rank_feature.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_rank_feature.json
@@ -5,7 +5,7 @@
             "field": "pagerank",
             "boost": 0.5,
             "sigmoid": {
-                "pivot": 7,
+                "pivot": 7.0,
                 "exponent": 0.6
             }
         }


### PR DESCRIPTION
## Description

This PR fixes incorrect typings in rank feature `saturation`, `sigmoid` and `log` query functions. More specifically, `pivot` and `scaling_factor` fields should accept floats instead of integers. This can be confirmed for each function:

- Saturation - elastic [source](https://github.com/elastic/elasticsearch/blob/1b2b202ef7560e81fee700f14521cd39974f8c10/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureQueryBuilder.java#L129), official client [source](https://github.com/elastic/elasticsearch-java/blob/7c46ddd904f31cab870ad5804003af29408ffe6d/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/RankFeatureFunctionSaturation.java#L62)
- Sigmoid - elastic [source](https://github.com/elastic/elasticsearch/blob/1b2b202ef7560e81fee700f14521cd39974f8c10/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureQueryBuilder.java#L203), official client [source](https://github.com/elastic/elasticsearch-java/blob/7c46ddd904f31cab870ad5804003af29408ffe6d/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/RankFeatureFunctionSigmoid.java#L61)
- Log - elastic [source](https://github.com/elastic/elasticsearch/blob/1b2b202ef7560e81fee700f14521cd39974f8c10/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureQueryBuilder.java#L66), official client [source](https://github.com/elastic/elasticsearch-java/blob/7c46ddd904f31cab870ad5804003af29408ffe6d/java-client/src/main/java/co/elastic/clients/elasticsearch/_types/query_dsl/RankFeatureFunctionLogarithm.java#L61)

Official docs can be found [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-rank-feature-query.html#:~:text=Saturation,-edit&text=The%20saturation%20function%20gives%20a,always%20(0%2C1)%20.).

## Context

The error was encounter while migrating from the deprecated [high level rest client](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/current/migrate-hlrc.html) to elastic4s. We are using saturation function with float values which cannot be changed, so the migration is on hold until the PR is merged. Please let me know if you need any additional input from me