### PR TITLE
Add indices options to update by query

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryAsyncRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryAsyncRequest.scala
@@ -2,6 +2,7 @@ package com.sksamuel.elastic4s.requests.update
 
 import com.sksamuel.elastic4s.Indexes
 import com.sksamuel.elastic4s.ext.OptionImplicits._
+import com.sksamuel.elastic4s.requests.admin.IndicesOptionsRequest
 import com.sksamuel.elastic4s.requests.common.{RefreshPolicy, Slice, Slicing}
 import com.sksamuel.elastic4s.requests.script.Script
 import com.sksamuel.elastic4s.requests.searches.queries.Query
@@ -23,7 +24,9 @@ case class UpdateByQueryAsyncRequest(indexes: Indexes,
                                      slice: Option[Slice] = None,
                                      timeout: Option[FiniteDuration] = None,
                                      shouldStoreResult: Option[Boolean] = None,
-                                     size: Option[Int] = None) extends BaseUpdateByQueryRequest {
+                                     size: Option[Int] = None,
+                                     indicesOptions: Option[IndicesOptionsRequest] = None) extends BaseUpdateByQueryRequest {
+
   def proceedOnConflicts(proceedOnConflicts: Boolean): UpdateByQueryAsyncRequest =
     copy(proceedOnConflicts = proceedOnConflicts.some)
 
@@ -61,6 +64,8 @@ case class UpdateByQueryAsyncRequest(indexes: Indexes,
 
   def shouldStoreResult(shouldStoreResult: Boolean): UpdateByQueryAsyncRequest =
     copy(shouldStoreResult = shouldStoreResult.some)
+
+  def indicesOptions(options: IndicesOptionsRequest): UpdateByQueryAsyncRequest = copy(indicesOptions = options.some)
 
   override val waitForCompletion: Option[Boolean] = Some(false)
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/update/UpdateByQueryRequest.scala
@@ -5,6 +5,7 @@ import com.sksamuel.elastic4s.requests.common.{RefreshPolicy, Slice, Slicing}
 import com.sksamuel.elastic4s.requests.script.Script
 import com.sksamuel.elastic4s.requests.searches.queries.Query
 import com.sksamuel.elastic4s.ext.OptionImplicits._
+import com.sksamuel.elastic4s.requests.admin.IndicesOptionsRequest
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -44,6 +45,8 @@ trait BaseUpdateByQueryRequest {
   val size: Option[Int]
 
   val waitForCompletion: Option[Boolean]
+
+  val indicesOptions: Option[IndicesOptionsRequest]
 }
 case class UpdateByQueryRequest(indexes: Indexes,
                                 query: Query,
@@ -63,7 +66,8 @@ case class UpdateByQueryRequest(indexes: Indexes,
                                 slice: Option[Slice] = None,
                                 timeout: Option[FiniteDuration] = None,
                                 shouldStoreResult: Option[Boolean] = None,
-                                size: Option[Int] = None) extends BaseUpdateByQueryRequest {
+                                size: Option[Int] = None,
+                                indicesOptions: Option[IndicesOptionsRequest] = None) extends BaseUpdateByQueryRequest {
 
   def proceedOnConflicts(proceedOnConflicts: Boolean): UpdateByQueryRequest =
     copy(proceedOnConflicts = proceedOnConflicts.some)
@@ -106,4 +110,5 @@ case class UpdateByQueryRequest(indexes: Indexes,
   def shouldStoreResult(shouldStoreResult: Boolean): UpdateByQueryRequest =
     copy(shouldStoreResult = shouldStoreResult.some)
 
+  def indicesOptions(options: IndicesOptionsRequest): UpdateByQueryRequest = copy(indicesOptions = options.some)
 }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/update/UpdateHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/update/UpdateHandlers.scala
@@ -6,7 +6,7 @@ import com.sksamuel.elastic4s.handlers.common.FetchSourceContextQueryParameterFn
 import com.sksamuel.elastic4s.handlers.script.ScriptBuilderFn
 import com.sksamuel.elastic4s.handlers.searches.queries
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
-import com.sksamuel.elastic4s.requests.common.{RefreshPolicyHttpValue, Slicing}
+import com.sksamuel.elastic4s.requests.common.{IndicesOptionsParams, RefreshPolicyHttpValue, Slicing}
 import com.sksamuel.elastic4s.requests.task.GetTask
 import com.sksamuel.elastic4s.requests.update.{BaseUpdateByQueryRequest, UpdateByQueryAsyncRequest, UpdateByQueryAsyncResponse, UpdateByQueryRequest, UpdateByQueryResponse, UpdateByQueryTask, UpdateRequest, UpdateResponse}
 import com.sksamuel.elastic4s.{BulkIndexByScrollFailure, ElasticError, ElasticRequest, ElasticUrlEncoder, Handler, HttpEntity, HttpResponse, ResponseHandler}
@@ -90,6 +90,10 @@ trait UpdateHandlers {
       request.slices.foreach(s =>
         if (s == Slicing.AutoSlices) params.put("slices", Slicing.AutoSlicesValue) else params.put("slices", s)
       )
+
+      request.indicesOptions.foreach { opts =>
+        IndicesOptionsParams(opts).foreach { case (key, value) => params.put(key, value) }
+      }
 
       val body = UpdateByQueryBodyFn(request)
       logger.debug(s"Update by query ${body.string}")


### PR DESCRIPTION
Indices options are available for search API, but not for update API. This PR adds them. 