### PR TITLE
Feat: add support for docvalue_fields and stored_fields in TopHitsAggregation

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/TopHitsAggregation.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/TopHitsAggregation.scala
@@ -16,10 +16,10 @@ case class TopHitsAggregation(name: String,
                               version: Option[Boolean] = None,
                               scripts: Map[String, Script] = Map.empty,
                               storedFields: Seq[String] = Nil,
-                              docValueFields: Seq[String] = Nil,
                               subaggs: Seq[AbstractAggregation] = Nil,
                               metadata: Map[String, AnyRef] = Map.empty,
-                              highlight: Option[Highlight] = None)
+                              highlight: Option[Highlight] = None,
+                              docValueFields: Seq[String] = Nil)
     extends Aggregation {
 
   type T = TopHitsAggregation

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/TopHitsAggregation.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/TopHitsAggregation.scala
@@ -16,6 +16,7 @@ case class TopHitsAggregation(name: String,
                               version: Option[Boolean] = None,
                               scripts: Map[String, Script] = Map.empty,
                               storedFields: Seq[String] = Nil,
+                              docValueFields: Seq[String] = Nil,
                               subaggs: Seq[AbstractAggregation] = Nil,
                               metadata: Map[String, AnyRef] = Map.empty,
                               highlight: Option[Highlight] = None)
@@ -41,6 +42,9 @@ case class TopHitsAggregation(name: String,
   def storedField(field: String): TopHitsAggregation                 = storedFields(field)
   def storedFields(first: String, rest: String*): TopHitsAggregation = storedFields(first +: rest)
   def storedFields(fields: Iterable[String]): TopHitsAggregation     = copy(storedFields = fields.toSeq)
+
+  def docValueFields(docValueFields: Iterable[String]): TopHitsAggregation =
+    copy(docValueFields = docValueFields.toSeq)
 
   def version(version: Boolean): TopHitsAggregation         = copy(version = version.some)
   def trackScores(trackScores: Boolean): TopHitsAggregation = copy(trackScores = trackScores.some)

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/TopHitsAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/TopHitsAggregationBuilder.scala
@@ -28,7 +28,10 @@ object TopHitsAggregationBuilder {
     agg.explain.foreach(builder.field("explain", _))
 
     if (agg.storedFields.nonEmpty)
-      builder.array("docvalue_fields", agg.storedFields.toArray)
+      builder.array("stored_fields", agg.storedFields.toArray)
+
+    if (agg.docValueFields.nonEmpty)
+      builder.array("docvalue_fields", agg.docValueFields.toArray)
 
     agg.highlight.foreach { highlight =>
       builder.rawField("highlight", HighlightBuilderFn(highlight))

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/TopHitsAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/TopHitsAggregationBuilder.scala
@@ -27,6 +27,9 @@ object TopHitsAggregationBuilder {
 
     agg.explain.foreach(builder.field("explain", _))
 
+    if (agg.storedFields.nonEmpty)
+      builder.array("docvalue_fields", agg.storedFields.toArray)
+
     agg.highlight.foreach { highlight =>
       builder.rawField("highlight", HighlightBuilderFn(highlight))
     }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/TopHitsAggregationBuilderTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/TopHitsAggregationBuilderTest.scala
@@ -13,10 +13,11 @@ class TopHitsAggregationBuilderTest extends AnyFunSuite with Matchers {
       .from(10)
       .version(true)
       .explain(false)
-      .storedFields(List("name"))
+      .docValueFields(List("name"))
+      .storedFields(List("currency"))
       .sortBy(List(FieldSort("price").sortMode(SortMode.Median)))
     TopHitsAggregationBuilder(q).string shouldBe
-      """{"top_hits":{"size":5,"from":10,"sort":[{"price":{"mode":"median","order":"asc"}}],"explain":false,"docvalue_fields":["name"],"version":true}}"""
+      """{"top_hits":{"size":5,"from":10,"sort":[{"price":{"mode":"median","order":"asc"}}],"explain":false,"stored_fields":["currency"],"docvalue_fields":["name"],"version":true}}"""
   }
 
   test("top hits aggregation builder should support highlighting") {

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/TopHitsAggregationBuilderTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/TopHitsAggregationBuilderTest.scala
@@ -13,9 +13,10 @@ class TopHitsAggregationBuilderTest extends AnyFunSuite with Matchers {
       .from(10)
       .version(true)
       .explain(false)
+      .storedFields(List("name"))
       .sortBy(List(FieldSort("price").sortMode(SortMode.Median)))
     TopHitsAggregationBuilder(q).string shouldBe
-      """{"top_hits":{"size":5,"from":10,"sort":[{"price":{"mode":"median","order":"asc"}}],"explain":false,"version":true}}"""
+      """{"top_hits":{"size":5,"from":10,"sort":[{"price":{"mode":"median","order":"asc"}}],"explain":false,"docvalue_fields":["name"],"version":true}}"""
   }
 
   test("top hits aggregation builder should support highlighting") {


### PR DESCRIPTION
Hello,

It is currently impossible to my understanding to add "docvalue_fields" to a top hits aggregation. Here's a proposition using the storedFields field.

Thanks