### PR TITLE
Add part of the index lifecycle management apis

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
@@ -1,7 +1,6 @@
 package com.sksamuel.elastic4s
 
-import com.sksamuel.elastic4s.api.{AggregationApi, AliasesApi, AnalyzeApi, AnalyzerApi, BulkApi, CatsApi, ClearRolesCacheApi, ClusterApi, CollapseApi, CountApi, CreateIndexApi, CreateRoleApi, CreateUserApi, DeleteApi, DeleteIndexApi, DeleteRoleApi, DeleteUserApi, ExistsApi, ExplainApi, ForceMergeApi, GetApi, HighlightApi, IndexAdminApi, IndexApi, IndexRecoveryApi, IndexTemplateApi, IngestApi, KnnApi, LocksApi, MappingApi, NodesApi, NormalizerApi, PipelineAggregationApi, PitApi, QueryApi, ReindexApi, ReloadSearchAnalyzersApi, RoleApi, ScoreApi, ScriptApi, ScrollApi, SearchApi, SearchTemplateApi, SettingsApi, SnapshotApi, SortApi, StoredScriptApi, SuggestionApi, SynonymsApi, TaskApi, TermVectorApi, TermsEnumApi, TokenFilterApi, TokenizerApi, TypesApi, UpdateApi, UserAdminApi, UserApi, ValidateApi}
-
+import com.sksamuel.elastic4s.api.{AggregationApi, AliasesApi, AnalyzeApi, AnalyzerApi, BulkApi, CatsApi, ClearRolesCacheApi, ClusterApi, CollapseApi, CountApi, CreateIndexApi, CreateRoleApi, CreateUserApi, DeleteApi, DeleteIndexApi, DeleteRoleApi, DeleteUserApi, ExistsApi, ExplainApi, ForceMergeApi, GetApi, HighlightApi, IndexAdminApi, IndexApi, IndexLifecycleManagementApi, IndexRecoveryApi, IndexTemplateApi, IngestApi, KnnApi, LocksApi, MappingApi, NodesApi, NormalizerApi, PipelineAggregationApi, PitApi, QueryApi, ReindexApi, ReloadSearchAnalyzersApi, RoleApi, ScoreApi, ScriptApi, ScrollApi, SearchApi, SearchTemplateApi, SettingsApi, SnapshotApi, SortApi, StoredScriptApi, SuggestionApi, SynonymsApi, TaskApi, TermVectorApi, TermsEnumApi, TokenFilterApi, TokenizerApi, TypesApi, UpdateApi, UserAdminApi, UserApi, ValidateApi}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
@@ -30,6 +29,7 @@ trait ElasticApi
     with HighlightApi
     with IndexApi
     with IndexAdminApi
+    with IndexLifecycleManagementApi
     with AnalyzeApi
     with IndexRecoveryApi
     with IndexTemplateApi

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
@@ -11,6 +11,7 @@ import com.sksamuel.elastic4s.handlers.explain.ExplainHandlers
 import com.sksamuel.elastic4s.handlers.get.GetHandlers
 import com.sksamuel.elastic4s.handlers.index.mapping.MappingHandlers
 import com.sksamuel.elastic4s.handlers.index.{IndexAdminHandlers, IndexHandlers, IndexStatsHandlers, IndexTemplateHandlers, RolloverHandlers}
+import com.sksamuel.elastic4s.handlers.indexlifecyclemanagement.IndexLifecycleManagementHandlers
 import com.sksamuel.elastic4s.handlers.locks.LocksHandlers
 import com.sksamuel.elastic4s.handlers.nodes.NodesHandlers
 import com.sksamuel.elastic4s.handlers.pit.PitHandlers
@@ -47,6 +48,7 @@ with GetHandlers
 with IndexHandlers
 with IndexAdminHandlers
 with IndexAliasHandlers
+with IndexLifecycleManagementHandlers
 with IndexStatsHandlers
 with IndexTemplateHandlers
 with IngestHandlers

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/IndexLifecycleManagementApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/IndexLifecycleManagementApi.scala
@@ -1,0 +1,11 @@
+package com.sksamuel.elastic4s.api
+
+import com.sksamuel.elastic4s.requests.indexlifecyclemanagement.{StartIlmRequest, GetIlmStatusRequest, StopIlmRequest}
+
+trait IndexLifecycleManagementApi {
+  def getIlmStatus: GetIlmStatusRequest = GetIlmStatusRequest()
+
+  def startIlm(): StartIlmRequest = StartIlmRequest()
+
+  def stopIlm(): StopIlmRequest = StopIlmRequest()
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/indexlifecyclemanagement/GetIlmStatusRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/indexlifecyclemanagement/GetIlmStatusRequest.scala
@@ -1,0 +1,13 @@
+package com.sksamuel.elastic4s.requests.indexlifecyclemanagement
+
+import scala.concurrent.duration.Duration
+
+import com.sksamuel.elastic4s.ext.OptionImplicits.RichOptionImplicits
+
+case class GetIlmStatusRequest(masterTimeout: Option[String] = None, timeout: Option[String] = None) {
+  def masterTimeout(timeout: Duration): GetIlmStatusRequest = copy(masterTimeout = s"${timeout.toNanos}nanos".some)
+  def masterTimeout(timeout: String): GetIlmStatusRequest = copy(masterTimeout = timeout.some)
+
+  def timeout(timeout: Duration): GetIlmStatusRequest = copy(timeout = s"${timeout.toNanos}nanos".some)
+  def timeout(timeout: String): GetIlmStatusRequest = copy(timeout = timeout.some)
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/indexlifecyclemanagement/GetIlmStatusResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/indexlifecyclemanagement/GetIlmStatusResponse.scala
@@ -1,0 +1,5 @@
+package com.sksamuel.elastic4s.requests.indexlifecyclemanagement
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class GetIlmStatusResponse(@JsonProperty("operation_mode") operationMode: String)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/indexlifecyclemanagement/StartIlmRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/indexlifecyclemanagement/StartIlmRequest.scala
@@ -1,0 +1,13 @@
+package com.sksamuel.elastic4s.requests.indexlifecyclemanagement
+
+import scala.concurrent.duration.Duration
+
+import com.sksamuel.elastic4s.ext.OptionImplicits.RichOptionImplicits
+
+case class StartIlmRequest(masterTimeout: Option[String] = None, timeout: Option[String] = None) {
+  def masterTimeout(timeout: Duration): StartIlmRequest = copy(masterTimeout = s"${timeout.toNanos}nanos".some)
+  def masterTimeout(timeout: String): StartIlmRequest = copy(masterTimeout = timeout.some)
+
+  def timeout(timeout: Duration): StartIlmRequest = copy(timeout = s"${timeout.toNanos}nanos".some)
+  def timeout(timeout: String): StartIlmRequest = copy(timeout = timeout.some)
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/indexlifecyclemanagement/StartIlmResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/indexlifecyclemanagement/StartIlmResponse.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.indexlifecyclemanagement
+
+case class StartIlmResponse(acknowledged: Boolean)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/indexlifecyclemanagement/StopIlmRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/indexlifecyclemanagement/StopIlmRequest.scala
@@ -1,0 +1,13 @@
+package com.sksamuel.elastic4s.requests.indexlifecyclemanagement
+
+import scala.concurrent.duration.Duration
+
+import com.sksamuel.elastic4s.ext.OptionImplicits.RichOptionImplicits
+
+case class StopIlmRequest(masterTimeout: Option[String] = None, timeout: Option[String] = None) {
+  def masterTimeout(timeout: Duration): StopIlmRequest = copy(masterTimeout = s"${timeout.toNanos}nanos".some)
+  def masterTimeout(timeout: String): StopIlmRequest = copy(masterTimeout = timeout.some)
+
+  def timeout(timeout: Duration): StopIlmRequest = copy(timeout = s"${timeout.toNanos}nanos".some)
+  def timeout(timeout: String): StopIlmRequest = copy(timeout = timeout.some)
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/indexlifecyclemanagement/StopIlmResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/indexlifecyclemanagement/StopIlmResponse.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.indexlifecyclemanagement
+
+case class StopIlmResponse(acknowledged: Boolean)

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/indexlifecyclemanagement/IndexLifecycleManagmentHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/indexlifecyclemanagement/IndexLifecycleManagmentHandlers.scala
@@ -1,0 +1,69 @@
+package com.sksamuel.elastic4s.handlers.indexlifecyclemanagement
+
+import com.sksamuel.elastic4s.handlers.ElasticErrorParser
+import com.sksamuel.elastic4s._
+import com.sksamuel.elastic4s.requests.indexlifecyclemanagement._
+
+trait IndexLifecycleManagementHandlers {
+  implicit object IndexLifecycleStatusHandler extends Handler[GetIlmStatusRequest, GetIlmStatusResponse] {
+    override def responseHandler: ResponseHandler[GetIlmStatusResponse] = new ResponseHandler[GetIlmStatusResponse] {
+      override def handle(response: HttpResponse): Either[ElasticError, GetIlmStatusResponse] = {
+        response.statusCode match {
+          case 200 | 201 => Right(ResponseHandler.fromResponse[GetIlmStatusResponse](response))
+          case 400 => Left(ElasticErrorParser.parse(response))
+          case _ => sys.error("Invalid response")
+        }
+      }
+    }
+
+    override def build(request: GetIlmStatusRequest): ElasticRequest = {
+      val endpoint = "/_ilm/status"
+
+      ElasticRequest("GET", endpoint)
+    }
+  }
+
+  implicit object IndexLifecycleStartHandler extends Handler[StartIlmRequest, StartIlmResponse] {
+    override def responseHandler: ResponseHandler[StartIlmResponse] = new ResponseHandler[StartIlmResponse] {
+      override def handle(response: HttpResponse): Either[ElasticError, StartIlmResponse] = {
+        response.statusCode match {
+          case 200 | 201 => Right(ResponseHandler.fromResponse[StartIlmResponse](response))
+          case 400 => Left(ElasticErrorParser.parse(response))
+          case _ => sys.error("Invalid response")
+        }
+      }
+    }
+
+    override def build(request: StartIlmRequest): ElasticRequest = {
+      val endpoint = "/_ilm/start"
+
+      val params = scala.collection.mutable.Map.empty[String, String]
+      request.masterTimeout.foreach(params.put("master_timeout", _))
+      request.timeout.foreach(params.put("timeout", _))
+
+      ElasticRequest("POST", endpoint, params.toMap)
+    }
+  }
+
+  implicit object IndexLifecycleStopHandler extends Handler[StopIlmRequest, StopIlmResponse] {
+    override def responseHandler: ResponseHandler[StopIlmResponse] = new ResponseHandler[StopIlmResponse] {
+      override def handle(response: HttpResponse): Either[ElasticError, StopIlmResponse] = {
+        response.statusCode match {
+          case 200 | 201 => Right(ResponseHandler.fromResponse[StopIlmResponse](response))
+          case 400 => Left(ElasticErrorParser.parse(response))
+          case _ => sys.error("Invalid response")
+        }
+      }
+    }
+
+    override def build(request: StopIlmRequest): ElasticRequest = {
+      val endpoint = "/_ilm/stop"
+
+      val params = scala.collection.mutable.Map.empty[String, String]
+      request.masterTimeout.foreach(params.put("master_timeout", _))
+      request.timeout.foreach(params.put("timeout", _))
+
+      ElasticRequest("POST", endpoint, params.toMap)
+    }
+  }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexlifecyclemanagement/IlmTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/indexlifecyclemanagement/IlmTest.scala
@@ -1,0 +1,63 @@
+package com.sksamuel.elastic4s.requests.indexlifecyclemanagement
+
+import scala.concurrent.duration.DurationInt
+
+import com.sksamuel.elastic4s.ElasticDsl
+import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.concurrent.Eventually
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class IlmTest extends AnyFlatSpec with Matchers with ElasticDsl with DockerTests with Eventually {
+   "ilm" should "return status" in {
+     client.execute {
+       startIlm()
+     }.await.result
+
+     eventually(timeout(5.seconds)) {
+       val resp = client.execute {
+         getIlmStatus
+       }.await.result
+       resp.operationMode shouldBe "RUNNING"
+     }
+  }
+
+  "ilm" should "stop" in {
+    val resp = client.execute {
+      stopIlm()
+    }.await.result
+    resp.acknowledged shouldBe true
+
+    eventually(timeout(5.seconds)) {
+      val resp = client.execute {
+        getIlmStatus
+      }.await.result
+      resp.operationMode shouldBe "STOPPED"
+    }
+  }
+
+  "ilm" should "start" in {
+    client.execute {
+      stopIlm()
+    }.await.result
+
+    eventually(timeout(5.seconds)) {
+      val resp = client.execute {
+        getIlmStatus
+      }.await.result
+      resp.operationMode shouldBe "STOPPED"
+    }
+
+    val resp = client.execute {
+      startIlm()
+    }.await.result
+    resp.acknowledged shouldBe true
+
+    eventually(timeout(5.seconds)) {
+      val resp = client.execute {
+        getIlmStatus
+      }.await.result
+      resp.operationMode shouldBe "RUNNING"
+    }
+  }
+}


### PR DESCRIPTION
Applying this PR will add the `_ilm/status`, `_ilm/start` and `_ilm/stop` commands of the Index lifecycle management APIs.