### PR TITLE
You Know, for Search

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticApi.scala
@@ -1,6 +1,6 @@
 package com.sksamuel.elastic4s
 
-import com.sksamuel.elastic4s.api.{AggregationApi, AliasesApi, AnalyzeApi, AnalyzerApi, BulkApi, CatsApi, ClearRolesCacheApi, ClusterApi, CollapseApi, CountApi, CreateIndexApi, CreateRoleApi, CreateUserApi, DeleteApi, DeleteIndexApi, DeleteRoleApi, DeleteUserApi, ExistsApi, ExplainApi, ForceMergeApi, GetApi, HighlightApi, IndexAdminApi, IndexApi, IndexLifecycleManagementApi, IndexRecoveryApi, IndexTemplateApi, IngestApi, KnnApi, LocksApi, MappingApi, NodesApi, NormalizerApi, PipelineAggregationApi, PitApi, QueryApi, ReindexApi, ReloadSearchAnalyzersApi, RoleApi, ScoreApi, ScriptApi, ScrollApi, SearchApi, SearchTemplateApi, SettingsApi, SnapshotApi, SortApi, StoredScriptApi, SuggestionApi, SynonymsApi, TaskApi, TermVectorApi, TermsEnumApi, TokenFilterApi, TokenizerApi, TypesApi, UpdateApi, UserAdminApi, UserApi, ValidateApi}
+import com.sksamuel.elastic4s.api.{AggregationApi, AliasesApi, AnalyzeApi, AnalyzerApi, BulkApi, CatsApi, ClearRolesCacheApi, ClusterApi, CollapseApi, CountApi, CreateIndexApi, CreateRoleApi, CreateUserApi, DeleteApi, DeleteIndexApi, DeleteRoleApi, DeleteUserApi, ExistsApi, ExplainApi, ForceMergeApi, GetApi, HighlightApi, IndexAdminApi, IndexApi, IndexLifecycleManagementApi, IndexRecoveryApi, IndexTemplateApi, IngestApi, KnnApi, LocksApi, MainApi, MappingApi, NodesApi, NormalizerApi, PipelineAggregationApi, PitApi, QueryApi, ReindexApi, ReloadSearchAnalyzersApi, RoleApi, ScoreApi, ScriptApi, ScrollApi, SearchApi, SearchTemplateApi, SettingsApi, SnapshotApi, SortApi, StoredScriptApi, SuggestionApi, SynonymsApi, TaskApi, TermVectorApi, TermsEnumApi, TokenFilterApi, TokenizerApi, TypesApi, UpdateApi, UserAdminApi, UserApi, ValidateApi}
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
@@ -35,6 +35,7 @@ trait ElasticApi
     with IndexTemplateApi
     with IngestApi
     with LocksApi
+    with MainApi
     with MappingApi
     with NodesApi
     with NormalizerApi

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/ElasticDsl.scala
@@ -13,6 +13,7 @@ import com.sksamuel.elastic4s.handlers.index.mapping.MappingHandlers
 import com.sksamuel.elastic4s.handlers.index.{IndexAdminHandlers, IndexHandlers, IndexStatsHandlers, IndexTemplateHandlers, RolloverHandlers}
 import com.sksamuel.elastic4s.handlers.indexlifecyclemanagement.IndexLifecycleManagementHandlers
 import com.sksamuel.elastic4s.handlers.locks.LocksHandlers
+import com.sksamuel.elastic4s.handlers.main.MainHandlers
 import com.sksamuel.elastic4s.handlers.nodes.NodesHandlers
 import com.sksamuel.elastic4s.handlers.pit.PitHandlers
 import com.sksamuel.elastic4s.handlers.reindex.ReindexHandlers
@@ -53,6 +54,7 @@ with IndexStatsHandlers
 with IndexTemplateHandlers
 with IngestHandlers
 with LocksHandlers
+with MainHandlers
 with MappingHandlers
 with NodesHandlers
 with ReindexHandlers

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/MainApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/MainApi.scala
@@ -1,0 +1,7 @@
+package com.sksamuel.elastic4s.api
+
+import com.sksamuel.elastic4s.requests.main.MainRequest
+
+trait MainApi {
+  def serverInfo: MainRequest = MainRequest()
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/main/MainRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/main/MainRequest.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.main
+
+case class MainRequest()

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/main/MainResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/main/MainResponse.scala
@@ -1,0 +1,23 @@
+package com.sksamuel.elastic4s.requests.main
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+case class MainResponse(
+  name: String,
+  @JsonProperty("cluster_name") clusterName: String,
+  @JsonProperty("cluster_uuid") clusterUuid: String,
+  version: MainResponse.Version,
+  tagline: String)
+
+object MainResponse {
+  case class Version(
+    number: String,
+    @JsonProperty("build_flavor") buildFlavor: String,
+    @JsonProperty("build_type") buildType: String,
+    @JsonProperty("build_hash") buildHash: String,
+    @JsonProperty("build_date") buildDate: String,
+    @JsonProperty("build_snapshot") buildSnapshot: Boolean,
+    @JsonProperty("lucene_version") luceneVersion: String,
+    @JsonProperty("minimum_wire_compatibility_version") minimumWireCompatibilityVersion: String,
+    @JsonProperty("minimum_index_compatibility_version") minimumIndexCompatibilityVersion: String)
+}

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/main/MainHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/main/MainHandlers.scala
@@ -1,0 +1,23 @@
+package com.sksamuel.elastic4s.handlers.main
+
+import com.sksamuel.elastic4s.requests.main._
+import com.sksamuel.elastic4s.{ElasticRequest, Handler, HttpResponse, ResponseHandler}
+
+trait MainHandlers {
+  implicit object MainHandlers extends Handler[MainRequest, MainResponse] {
+
+    override def responseHandler: ResponseHandler[MainResponse] = new ResponseHandler[MainResponse] {
+      override def handle(response: HttpResponse): Right[Nothing, MainResponse] =
+        response.statusCode match {
+          case 200 => Right(ResponseHandler.fromResponse[MainResponse](response))
+          case _ => sys.error("Invalid response")
+        }
+    }
+
+    override def build(request: MainRequest): ElasticRequest = {
+      val endpoint = "/"
+
+      ElasticRequest("GET", endpoint)
+    }
+  }
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/main/MainTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/main/MainTest.scala
@@ -1,0 +1,16 @@
+package com.sksamuel.elastic4s.requests.main
+
+import com.sksamuel.elastic4s.ElasticDsl
+import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class MainTest extends AnyFlatSpec with Matchers with ElasticDsl with DockerTests {
+  "main" should "return the tagline" in {
+    val resp = client.execute {
+      serverInfo
+    }.await.result
+
+    resp.tagline shouldBe "You Know, for Search"
+  }
+}


### PR DESCRIPTION
Applying this PR will add the "serverInfo" GET `/` request, returning version info and the famous tagline. The naming of `serviceInfo`, `MainRequest` and `MainResponse` comes from the Elasticsearch code base, there is no entry in the API documentation about the request.