### PR TITLE
Add range and regexp rules to intervals query

### DIFF
--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/IntervalsQueryBuilderFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/IntervalsQueryBuilderFnTest.scala
@@ -123,4 +123,55 @@ class IntervalsQueryBuilderFnTest extends AnyFunSuite with Matchers with GivenWh
       |  }
       |}
     """.stripMargin.replace("\n", "")
+
+  test("Should correctly build intervals query with a regex rule") {
+    def expected =
+      """
+        |{
+        |  "intervals": {
+        |    "my_text": {
+        |      "regexp": {
+        |        "pattern": "*",
+        |        "analyzer": "standard",
+        |        "use_field": "my_text"
+        |      }
+        |    }
+        |  }
+        |}
+      """.stripMargin
+    Given("An intervals query with a regex rule")
+    val query = IntervalsQuery("my_text", Regexp(pattern = "*", analyzer = Some("standard"), useField = Some("my_text")))
+
+    When("Intervals query is built")
+    val queryBody = queries.IntervalsQueryBuilderFn(query)
+
+    Then("query should have right fields")
+    queryBody.string should matchJson(expected)
+  }
+
+  test("Should correctly build intervals query with a range rule") {
+    def expected =
+      """
+        |{
+        |  "intervals": {
+        |    "my_text": {
+        |      "range": {
+        |        "gte": "a",
+        |        "lte": "z",
+        |        "analyzer": "standard",
+        |        "use_field": "my_text"
+        |      }
+        |    }
+        |  }
+        |}
+      """.stripMargin
+    Given("An intervals query with a regex rule")
+    val query = IntervalsQuery("my_text", Range(gte = Some("a"), lte = Some("z"), analyzer = Some("standard"), useField = Some("my_text")))
+
+    When("Intervals query is built")
+    val queryBody = queries.IntervalsQueryBuilderFn(query)
+
+    Then("query should have right fields")
+    queryBody.string should matchJson(expected)
+  }
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/IntervalsQuery.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/IntervalsQuery.scala
@@ -39,6 +39,15 @@ case class Wildcard(pattern: String,
   def useField(useField: String): Wildcard = copy(useField = useField.some)
 }
 
+case class Regexp(pattern: String,
+                  analyzer: Option[String] = None,
+                  useField: Option[String] = None) extends IntervalsRule {
+  override def toString = "regexp"
+
+  def analyzer(analyzer: String): Regexp = copy(analyzer = analyzer.some)
+  def useField(useField: String): Regexp = copy(useField = useField.some)
+}
+
 case class Fuzzy(term: String,
                  prefixLength: Option[String] = None,
                  transpositions: Option[Boolean] = None,
@@ -52,6 +61,22 @@ case class Fuzzy(term: String,
   def fuzziness(fuzziness: String): Fuzzy = copy(fuzziness = fuzziness.some)
   def analyzer(analyzer: String): Fuzzy = copy(analyzer = analyzer.some)
   def useField(useField: String): Fuzzy = copy(useField = useField.some)
+}
+
+case class Range(gt: Option[String] = None,
+                 gte: Option[String] = None,
+                 lt: Option[String] = None,
+                 lte: Option[String] = None,
+                 analyzer: Option[String] = None,
+                 useField: Option[String] = None) extends IntervalsRule {
+  override def toString = "range"
+
+  def gt(gt: String): Range = copy(gt = gt.some, gte = None)
+  def gte(gte: String): Range = copy(gte = gte.some, gt = None)
+  def lt(lt: String): Range = copy(lt = lt.some, lte = None)
+  def lte(lte: String): Range = copy(lte = lte.some, lt = None)
+  def analyzer(analyzer: String): Range = copy(analyzer = analyzer.some)
+  def useField(useField: String): Range = copy(useField = useField.some)
 }
 
 case class AllOf(intervals: List[IntervalsRule],

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/IntervalsQueryBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/IntervalsQueryBuilderFn.scala
@@ -3,7 +3,7 @@ package com.sksamuel.elastic4s.handlers.searches.queries
 import com.sksamuel.elastic4s.handlers.script
 import com.sksamuel.elastic4s.handlers.searches.queries
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
-import com.sksamuel.elastic4s.requests.searches.queries.{AllOf, AnyOf, Fuzzy, IntervalsFilter, IntervalsQuery, IntervalsRule, Match, Prefix, Wildcard}
+import com.sksamuel.elastic4s.requests.searches.queries.{AllOf, AnyOf, Fuzzy, IntervalsFilter, IntervalsQuery, IntervalsRule, Match, Prefix, Range, Regexp, Wildcard}
 
 object IntervalsFilterBuilderFn {
   def apply(f: IntervalsFilter): XContentBuilder = {
@@ -46,12 +46,27 @@ object IntervalsRuleBuilderFn {
         analyzer.foreach(builder.field("analyzer", _))
         useField.foreach(builder.field("use_field", _))
         builder.endObject()
+      case Regexp(pattern: String, analyzer: Option[String], useField: Option[String]) =>
+        builder.startObject("regexp")
+        builder.field("pattern", pattern)
+        analyzer.foreach(builder.field("analyzer", _))
+        useField.foreach(builder.field("use_field", _))
+        builder.endObject()
       case Fuzzy(term: String, prefixLength: Option[String], transpositions: Option[Boolean], fuzziness: Option[String], analyzer: Option[String], useField: Option[String]) =>
         builder.startObject("fuzzy")
         builder.field("term", term)
         prefixLength.foreach(builder.field("prefix_length", _))
         transpositions.foreach(builder.field("transpositions", _))
         fuzziness.foreach(builder.field("fuzziness", _))
+        analyzer.foreach(builder.field("analyzer", _))
+        useField.foreach(builder.field("use_field", _))
+        builder.endObject()
+      case Range(gt: Option[String], gte: Option[String], lt: Option[String], lte: Option[String], analyzer: Option[String], useField: Option[String]) =>
+        builder.startObject("range")
+        gt.foreach(builder.field("gt", _))
+        gte.foreach(builder.field("gte", _))
+        lt.foreach(builder.field("lt", _))
+        lte.foreach(builder.field("lte", _))
         analyzer.foreach(builder.field("analyzer", _))
         useField.foreach(builder.field("use_field", _))
         builder.endObject()


### PR DESCRIPTION
Applying this PR will add the range and regexp rules to the intervals query, which were introduced in Elasticsearch 8.16.