### PR TITLE
Change http4s connectivity test

### DIFF
--- a/elastic4s-client-http4s/src/test/scala/com/sksamuel/elastic4s/http4s/Http4sRequestHttpClientTest.scala
+++ b/elastic4s-client-http4s/src/test/scala/com/sksamuel/elastic4s/http4s/Http4sRequestHttpClientTest.scala
@@ -18,8 +18,8 @@ class Http4sRequestHttpClientTest extends AnyFlatSpec with Matchers with DockerT
 
   "Http4sRequestHttpClient" should "be able to call elasticsearch" in {
     client.execute {
-      catHealth()
-    }.await.result.status shouldBe "green"
+      serverInfo
+    }.await.result.tagline shouldBe "You Know, for Search"
   }
 
   it should "be able to propagate headers if included" in {


### PR DESCRIPTION
The current test sometimes gives back "yellow" instead of "green". In the context of this test "yellow" would be valid as well. Decided to use the new serverInfo request instead.