### PR TITLE
Use http4s.Uri in Http4sClient

### DIFF
--- a/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/Http4sClient.scala
+++ b/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/Http4sClient.scala
@@ -18,21 +18,6 @@ object Http4sClient {
 
   def usingIO(
     client: http4s.client.Client[IO],
-    endpoint: ElasticNodeEndpoint,
-  )(implicit runtime: IORuntime): Http4sClient[IO] = {
-    val ioRunner = new CallbackRunner[IO] {
-      override def run[A](fa: IO[A], cb: Either[Throwable, A] => Unit): Unit = fa.unsafeRunAsync(cb)
-    }
-
-    Http4sClient(
-      client = client,
-      endpoint = endpoint,
-      runner = ioRunner
-    )
-  }
-
-  def usingIO(
-    client: http4s.client.Client[IO],
     endpoint: http4s.Uri,
   )(implicit runtime: IORuntime): Http4sClient[IO] = {
     val ioRunner = new CallbackRunner[IO] {

--- a/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/Http4sClient.scala
+++ b/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/Http4sClient.scala
@@ -31,7 +31,7 @@ object Http4sClient {
     )
   }
 
-  @deprecated("Use usingIO with http4s.Uri", "8.15.5")
+  @deprecated("Use usingIO with http4s.Uri", "8.16.0")
   def usingIO(
     client: http4s.client.Client[IO],
     endpoint: ElasticNodeEndpoint,

--- a/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/Http4sClient.scala
+++ b/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/Http4sClient.scala
@@ -31,6 +31,22 @@ object Http4sClient {
     )
   }
 
+  @deprecated("Use usingIO with http4s.Uri", "8.15.5")
+  def usingIO(
+    client: http4s.client.Client[IO],
+    endpoint: ElasticNodeEndpoint,
+  )(implicit runtime: IORuntime): Http4sClient[IO] = {
+    val ioRunner = new CallbackRunner[IO] {
+      override def run[A](fa: IO[A], cb: Either[Throwable, A] => Unit): Unit = fa.unsafeRunAsync(cb)
+    }
+
+    Http4sClient(
+      client = client,
+      endpoint = endpoint,
+      runner = ioRunner
+    )
+  }
+
   def apply[F[_] : Async : Files](
     client: http4s.client.Client[F],
     endpoint: ElasticNodeEndpoint,

--- a/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/Http4sClient.scala
+++ b/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/Http4sClient.scala
@@ -24,6 +24,21 @@ object Http4sClient {
       override def run[A](fa: IO[A], cb: Either[Throwable, A] => Unit): Unit = fa.unsafeRunAsync(cb)
     }
 
+    Http4sClient(
+      client = client,
+      endpoint = endpoint,
+      runner = ioRunner
+    )
+  }
+
+  def usingIO(
+    client: http4s.client.Client[IO],
+    endpoint: http4s.Uri,
+  )(implicit runtime: IORuntime): Http4sClient[IO] = {
+    val ioRunner = new CallbackRunner[IO] {
+      override def run[A](fa: IO[A], cb: Either[Throwable, A] => Unit): Unit = fa.unsafeRunAsync(cb)
+    }
+
     new Http4sClient(
       client = client,
       endpoint = endpoint,
@@ -31,11 +46,27 @@ object Http4sClient {
     )
   }
 
+  def apply[F[_] : Async : Files](
+    client: http4s.client.Client[F],
+    endpoint: ElasticNodeEndpoint,
+    runner: CallbackRunner[F],
+  ): Http4sClient[F] = {
+    val uri = http4s.Uri(
+      scheme = Some(http4s.Uri.Scheme.http),
+      authority = Some(http4s.Uri.Authority(host = http4s.Uri.RegName(endpoint.host), port = Some(endpoint.port))),
+      )
+    new Http4sClient(
+      client = client,
+      endpoint = uri,
+      runner = runner
+    )
+  }
+
 }
 
 class Http4sClient[F[_] : Async : Files](
   client: http4s.client.Client[F],
-  endpoint: ElasticNodeEndpoint,
+  endpoint: http4s.Uri,
   runner: CallbackRunner[F],
 ) extends elastic4s.HttpClient with RequestResponseConverters {
 

--- a/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/RequestResponseConverters.scala
+++ b/elastic4s-client-http4s/src/main/scala/com/sksamuel/elastic4s/http4s/RequestResponseConverters.scala
@@ -3,7 +3,6 @@ package com.sksamuel.elastic4s.http4s
 import cats.effect.Async
 import cats.syntax.all._
 import com.sksamuel.elastic4s
-import com.sksamuel.elastic4s.ElasticNodeEndpoint
 import fs2.io.file.Files
 import org.http4s
 
@@ -12,15 +11,11 @@ import scala.language.higherKinds
 trait RequestResponseConverters extends Elastic4sEntityEncoders {
 
   def elasticRequestToHttp4sRequest[F[_] : Async : Files](
-    endpoint: ElasticNodeEndpoint,
+    endpoint: http4s.Uri,
     request: elastic4s.ElasticRequest,
   ): http4s.Request[F] = {
-    val uri = http4s.Uri(
-      scheme = http4s.Uri.Scheme.fromString(endpoint.protocol).toOption,
-      authority = http4s.Uri.Authority(
-        host = http4s.Uri.RegName(endpoint.host),
-        port = endpoint.port.some
-      ).some,
+    val uri =
+      endpoint.copy(
       path = http4s.Uri.Path(request.endpoint.stripPrefix("/").split('/').map(http4s.Uri.Path.Segment(_)).toVector),
       query = http4s.Query.fromPairs(request.params.toList: _*)
     )

--- a/elastic4s-client-http4s/src/test/scala/com/sksamuel/elastic4s/http4s/Http4sRequestHttpClientTest.scala
+++ b/elastic4s-client-http4s/src/test/scala/com/sksamuel/elastic4s/http4s/Http4sRequestHttpClientTest.scala
@@ -3,16 +3,16 @@ package com.sksamuel.elastic4s.http4s
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import com.sksamuel.elastic4s.testkit.DockerTests
-import com.sksamuel.elastic4s.{Authentication, CommonRequestOptions, ElasticClient, ElasticNodeEndpoint}
+import com.sksamuel.elastic4s.{Authentication, CommonRequestOptions, ElasticClient }
 import org.http4s.ember.client.EmberClientBuilder
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class Http4sRequestHttpClientTest extends AnyFlatSpec with Matchers with DockerTests {
-  private val http4s = EmberClientBuilder.default[IO].build.allocated.unsafeRunSync()._1
+  private val emberClient = EmberClientBuilder.default[IO].build.allocated.unsafeRunSync()._1
   private val http4sClient = Http4sClient.usingIO(
-    http4s,
-    ElasticNodeEndpoint("http", elasticHost, elasticPort.toInt, None),
+    emberClient,
+    org.http4s.Uri.unsafeFromString(s"http://$elasticHost:$elasticPort"),
   )
   override val client: ElasticClient = ElasticClient(http4sClient)
 


### PR DESCRIPTION
This is to avoid conversion between ElasticNodeEndpoint to http4s.Uri
for every request. Which'll save us some allocation, hence more
performance. This also allows users to pass http4s.Uri directly to
Http4sClient.