### PR TITLE
Add support for Get and Delete snapshot repository API

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/SnapshotApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/SnapshotApi.scala
@@ -3,6 +3,7 @@ package com.sksamuel.elastic4s.api
 import com.sksamuel.elastic4s.requests.snapshots.{
   CreateRepositoryRequest,
   CreateSnapshotRequest,
+  DeleteRepositoryRequest,
   DeleteSnapshotRequest,
   GetRepositoryRequest,
   GetSnapshotsRequest,
@@ -61,4 +62,6 @@ trait SnapshotApi {
   }
 
   def getRepository(repositoryName: String) = GetRepositoryRequest(repositoryName)
+
+  def deleteRepository(repositoryName: String) = DeleteRepositoryRequest(repositoryName)
 }

--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/SnapshotApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/SnapshotApi.scala
@@ -4,6 +4,7 @@ import com.sksamuel.elastic4s.requests.snapshots.{
   CreateRepositoryRequest,
   CreateSnapshotRequest,
   DeleteSnapshotRequest,
+  GetRepositoryRequest,
   GetSnapshotsRequest,
   RestoreSnapshotRequest
 }
@@ -58,4 +59,6 @@ trait SnapshotApi {
     @deprecated("use createRepository(name: String, repository: String)", "6.0.2")
     def `type`(`type`: String) = CreateRepositoryRequest(name, `type`)
   }
+
+  def getRepository(repositoryName: String) = GetRepositoryRequest(repositoryName)
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/snapshots/DeleteRepositoryRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/snapshots/DeleteRepositoryRequest.scala
@@ -1,0 +1,3 @@
+package com.sksamuel.elastic4s.requests.snapshots
+
+case class DeleteRepositoryRequest(name: String)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/snapshots/GetRepositoryRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/snapshots/GetRepositoryRequest.scala
@@ -1,0 +1,10 @@
+package com.sksamuel.elastic4s.requests.snapshots
+
+import com.sksamuel.elastic4s.ext.OptionImplicits._
+
+case class GetRepositoryRequest(
+    name: String,
+    local: Option[Boolean] = None
+) {
+  def local(l: Boolean): GetRepositoryRequest = copy(local = l.some)
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/snapshots/response.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/snapshots/response.scala
@@ -1,9 +1,10 @@
 package com.sksamuel.elastic4s.requests.snapshots
 
-import com.fasterxml.jackson.annotation.{JsonProperty, JsonSubTypes, JsonTypeInfo}
+import com.fasterxml.jackson.annotation.{JsonAnySetter, JsonProperty, JsonSubTypes, JsonTypeInfo}
 import com.sksamuel.elastic4s.ElasticError
 import com.sksamuel.elastic4s.requests.common.Shards
 
+import scala.collection.mutable
 import scala.concurrent.duration._
 
 case class CreateRepositoryResponse(acknowledged: Boolean)
@@ -21,6 +22,17 @@ case class CreateSnapshotResponseAsync(accepted: Boolean)  extends CreateSnapsho
 case class CreateSnapshotResponseAwait(snapshot: Snapshot) extends CreateSnapshotResponse {
   override def succeeded: Boolean = snapshot.state == "SUCCESS"
 }
+
+case class GetRepositoryResponse() {
+  private val _repositories = mutable.Map[String, Repository]()
+
+  // noinspection ScalaUnusedSymbol
+  @JsonAnySetter private def setRepositories(k: String, v: Repository): Unit = _repositories.put(k, v)
+
+  def repositories: Map[String, Repository] = _repositories.toMap
+}
+case class Repository(`type`: String, settings: Map[String, AnyRef] = Map.empty)
+
 case class GetSnapshotResponse(snapshots: Seq[Snapshot], failures: Map[String, ElasticError])
 case class Snapshot(
     snapshot: String,

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/snapshots/response.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/snapshots/response.scala
@@ -33,6 +33,8 @@ case class GetRepositoryResponse() {
 }
 case class Repository(`type`: String, settings: Map[String, AnyRef] = Map.empty)
 
+case class DeleteRepositoryResponse(acknowledged: Boolean)
+
 case class GetSnapshotResponse(snapshots: Seq[Snapshot], failures: Map[String, ElasticError])
 case class Snapshot(
     snapshot: String,

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/snapshot/SnapshotHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/snapshot/SnapshotHandlers.scala
@@ -6,6 +6,8 @@ import com.sksamuel.elastic4s.requests.snapshots.{
   CreateRepositoryResponse,
   CreateSnapshotRequest,
   CreateSnapshotResponse,
+  DeleteRepositoryRequest,
+  DeleteRepositoryResponse,
   DeleteSnapshotRequest,
   DeleteSnapshotResponse,
   GetRepositoryRequest,
@@ -50,6 +52,13 @@ trait SnapshotHandlers {
       request.local.map(_.toString).foreach(params.put("local", _))
 
       ElasticRequest("GET", endpoint, params.toMap)
+    }
+  }
+
+  implicit object DeleteRepositoryHandler extends Handler[DeleteRepositoryRequest, DeleteRepositoryResponse] {
+    override def build(request: DeleteRepositoryRequest): ElasticRequest = {
+      val endpoint = s"/_snapshot/" + request.name
+      ElasticRequest("DELETE", endpoint)
     }
   }
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/snapshot/SnapshotHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/snapshot/SnapshotHandlers.scala
@@ -8,6 +8,8 @@ import com.sksamuel.elastic4s.requests.snapshots.{
   CreateSnapshotResponse,
   DeleteSnapshotRequest,
   DeleteSnapshotResponse,
+  GetRepositoryRequest,
+  GetRepositoryResponse,
   GetSnapshotResponse,
   GetSnapshotsRequest,
   RestoreSnapshotRequest,
@@ -37,6 +39,17 @@ trait SnapshotHandlers {
       val entity = HttpEntity(body.string, "application/json")
 
       ElasticRequest("PUT", endpoint, params.toMap, entity)
+    }
+  }
+
+  implicit object GetRepositoryHandler extends Handler[GetRepositoryRequest, GetRepositoryResponse] {
+    override def build(request: GetRepositoryRequest): ElasticRequest = {
+      val endpoint = s"/_snapshot/" + request.name
+
+      val params = scala.collection.mutable.Map.empty[String, String]
+      request.local.map(_.toString).foreach(params.put("local", _))
+
+      ElasticRequest("GET", endpoint, params.toMap)
     }
   }
 

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/snapshots/SnapshotTest.scala
@@ -41,6 +41,29 @@ class SnapshotTest extends AnyFlatSpec with Matchers with DockerTests {
     }.await.error.`type` shouldBe "repository_missing_exception"
   }
 
+  "deleteRepository" should "delete a snapshot repository" in {
+    val deleteRepoName = "delete_repotest_" + UUID.randomUUID().toString
+    client.execute {
+      createRepository(deleteRepoName, "fs").settings(
+        Map("location" -> ("/tmp/elastic4s/backup_" + UUID.randomUUID.toString))
+      )
+    }.await
+
+    client.execute {
+      deleteRepository(deleteRepoName)
+    }.await.result.acknowledged shouldBe true
+
+    client.execute {
+      getRepository(deleteRepoName)
+    }.await.error.`type` shouldBe "repository_missing_exception"
+  }
+
+  it should "error when the repo does not exist" in {
+    client.execute {
+      getRepository("not_exists")
+    }.await.error.`type` shouldBe "repository_missing_exception"
+  }
+
   "createSnapshot" should "create a new snapshot" in {
     // ensure there's at least one index to restore, so that we can test some of the behaviour around that
     createIdx("tmpidx").isSuccess shouldBe true


### PR DESCRIPTION
Support getting and deleting snapshot repositories.
[get API doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/get-snapshot-repo-api.html)
[delete API doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/delete-snapshot-repo-api.html)