### PR TITLE
feat: adds boost support into interval queries

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/IntervalsQuery.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/IntervalsQuery.scala
@@ -3,7 +3,7 @@ package com.sksamuel.elastic4s.requests.searches.queries
 import com.sksamuel.elastic4s.requests.script.Script
 import com.sksamuel.elastic4s.ext.OptionImplicits._
 
-case class IntervalsQuery(field: String, rule: IntervalsRule) extends Query
+case class IntervalsQuery(field: String, rule: IntervalsRule, boost: Option[Double] = None) extends Query
 
 sealed trait IntervalsRule
 case class Match(

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/IntervalsQueryBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/IntervalsQueryBuilderFn.scala
@@ -143,7 +143,13 @@ object IntervalsQueryBuilderFn {
   def apply(q: IntervalsQuery): XContentBuilder = {
     val builder = XContentFactory.jsonBuilder()
     builder.startObject("intervals")
-    builder.rawField(q.field, IntervalsRuleBuilderFn(q.rule))
+    builder.rawField(
+      q.field, {
+        val ruleBuilder = IntervalsRuleBuilderFn(q.rule)
+        q.boost.foreach(ruleBuilder.field("boost", _))
+        ruleBuilder
+      }
+    )
     builder.endObject()
   }
 }


### PR DESCRIPTION
adds the "[undocumented](https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/index/query/IntervalQueryBuilder.java#L92-L95)" boost into intervals queries