### PR TITLE
Add deprecated SearchResponse.apply method without pitId

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchResponse.scala
@@ -63,3 +63,18 @@ case class SearchResponse(
   def to[T: HitReader: ClassTag]: IndexedSeq[T] = hits.hits.map(_.to[T]).toIndexedSeq
   def safeTo[T: HitReader]: IndexedSeq[Try[T]]  = hits.hits.map(_.safeTo[T]).toIndexedSeq
 }
+
+object SearchResponse {
+  @deprecated("Use apply with pitId instead", "8.17.1")
+  def apply(
+      took: Long,
+      isTimedOut: Boolean,
+      isTerminatedEarly: Boolean,
+      suggest: Map[String, Seq[SuggestionResult]],
+      _shards: Shards,
+      scrollId: Option[String],
+      _aggregationsAsMap: Map[String, Any],
+      hits: SearchHits
+  ): SearchResponse =
+    SearchResponse(took, isTimedOut, isTerminatedEarly, suggest, _shards, scrollId, None, _aggregationsAsMap, hits)
+}


### PR DESCRIPTION
Follows https://github.com/Philippus/elastic4s/pull/3277. If you build your own `SearchResponse`, your code will break after updating to 8.17.0. Applying this PR will add a (deprecated) `SearchResponse.apply` method without the `pitId` field.