### PR TITLE
Add project/metals.sbt to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ src_managed/
 project/boot/
 project/plugins/project/
 project/credentials.sbt
+project/metals.sbt
 credentials.sbt
 test-output/
 

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,4 +1,0 @@
-// DO NOT EDIT! This file is auto-generated.
-// This file enables sbt-bloop to create bloop config files.
-
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "2.0.9")


### PR DESCRIPTION
`project/metals.sbt` is auto generated, so it's good to keep it's ignored.