### PR TITLE
fix: boosting query parameters

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/QueryApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/QueryApi.scala
@@ -80,8 +80,8 @@ trait QueryApi {
   implicit def string2query(string: String): SimpleStringQuery = SimpleStringQuery(string)
   implicit def tuple2query(kv: (String, String)): TermQuery    = TermQuery(kv._1, kv._2)
 
-  def boostingQuery(positiveQuery: Query, negativeQuery: Query): BoostingQuery =
-    BoostingQuery(positiveQuery, negativeQuery)
+  def boostingQuery(positiveQuery: Query, negativeQuery: Query, negativeBoost: Double): BoostingQuery =
+    BoostingQuery(positiveQuery, negativeQuery, negativeBoost)
 
   def combinedFieldsQuery(query: String, fields: Seq[String]): CombinedFieldsQuery =
     CombinedFieldsQuery(query, fields.map(_ -> None))

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/BoostingQuery.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/BoostingQuery.scala
@@ -3,14 +3,5 @@ package com.sksamuel.elastic4s.requests.searches.queries
 case class BoostingQuery(
     positiveQuery: Query,
     negativeQuery: Query,
-    queryName: Option[String] = None,
-    boost: Option[Double] = None,
-    negativeBoost: Option[Double] = None
-) extends Query {
-
-  def withQueryName(queryName: String): BoostingQuery = copy(queryName = Option(queryName))
-
-  def boost(boost: Double): BoostingQuery                 = copy(boost = Option(boost))
-  def negativeBoost(negativeBoost: Double): BoostingQuery = copy(negativeBoost = Option(negativeBoost))
-  def queryName(queryName: String): BoostingQuery         = copy(queryName = Option(queryName))
-}
+    negativeBoost: Double
+) extends Query

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/compound/BoostingQueryBodyFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/compound/BoostingQueryBodyFn.scala
@@ -12,8 +12,7 @@ object BoostingQueryBodyFn {
     builder.startObject("boosting")
     builder.rawField("positive", QueryBuilderFn(q.positiveQuery))
     builder.rawField("negative", queries.QueryBuilderFn(q.negativeQuery))
-    q.negativeBoost.foreach(builder.field("negative_boost", _))
-    q.boost.foreach(builder.field("boost", _))
+    builder.field("negative_boost", q.negativeBoost)
     builder.endObject()
     builder.endObject()
   }

--- a/elastic4s-tests/src/test/resources/json/search/search_boosting.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_boosting.json
@@ -11,8 +11,7 @@
                     "query": "jethro tull"
                 }
             },
-            "negative_boost": 5.6,
-            "boost": 7.6
+            "negative_boost": 5.6
         }
     },
     "size": 5

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/SearchDslTest.scala
@@ -162,7 +162,7 @@ class SearchDslTest extends AnyFlatSpec with MockitoSugar with JsonSugar with On
 
   it should "generate json for a boosting query" in {
     val req = search("*") limit 5 query {
-      boostingQuery(stringQuery("coldplay"), stringQuery("jethro tull")) negativeBoost 5.6 boost 7.6
+      boostingQuery(stringQuery("coldplay"), stringQuery("jethro tull"), 5.6)
     }
     req.request.entity.get.get should matchJsonResource("/json/search/search_boosting.json")
   }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/BoostingQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/BoostingQueryTest.scala
@@ -1,0 +1,43 @@
+package com.sksamuel.elastic4s.search.queries
+
+import com.sksamuel.elastic4s.requests.common.RefreshPolicy
+import com.sksamuel.elastic4s.testkit.DockerTests
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.util.Try
+
+class BoostingQueryTest extends AnyFlatSpec with Matchers with DockerTests {
+
+  Try {
+    client.execute {
+      deleteIndex("fonts")
+    }.await
+  }
+
+  client.execute {
+    createIndex("fonts")
+  }.await
+
+  client.execute {
+    bulk(
+      indexInto("fonts").fields("name" -> "helvetica"),
+      indexInto("fonts").fields("name" -> "arial"),
+      indexInto("fonts").fields("name" -> "verdana")
+    ).refresh(RefreshPolicy.Immediate)
+  }.await
+
+  "boosting query" should "boost" in {
+    client.execute {
+      search("fonts").query {
+        boostingQuery(matchAllQuery(), "verdana", 0.5)
+      }
+    }.await.result.hits.hits.map(_.sourceField("name")) shouldBe Array("helvetica", "arial", "verdana")
+
+    client.execute {
+      search("fonts").query {
+        boostingQuery(matchAllQuery(), "arial", 0.5)
+      }
+    }.await.result.hits.hits.map(_.sourceField("name")) shouldBe Array("helvetica", "verdana", "arial")
+  }
+}


### PR DESCRIPTION
- Removed not used `queryName` field,
- Removed incorrect `boost` field,
- Made required `negativeBoost` field.

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-boosting-query.html#boosting-top-level-params

Previously it was possible to create boosting query with incorrect body, for example with field `boost` that doesn't exist, or without required `negativeBoost`.