### PR TITLE
Add deprecated BoostingQuery.apply method without negativeBoost

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/QueryApi.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/api/QueryApi.scala
@@ -80,6 +80,10 @@ trait QueryApi {
   implicit def string2query(string: String): SimpleStringQuery = SimpleStringQuery(string)
   implicit def tuple2query(kv: (String, String)): TermQuery    = TermQuery(kv._1, kv._2)
 
+  @deprecated("Use boostingQuery with required negativeBoost parameter instead", "8.18.0")
+  def boostingQuery(positiveQuery: Query, negativeQuery: Query): BoostingQuery =
+    BoostingQuery(positiveQuery, negativeQuery)
+
   def boostingQuery(positiveQuery: Query, negativeQuery: Query, negativeBoost: Double): BoostingQuery =
     BoostingQuery(positiveQuery, negativeQuery, negativeBoost)
 

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/BoostingQuery.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/queries/BoostingQuery.scala
@@ -4,4 +4,25 @@ case class BoostingQuery(
     positiveQuery: Query,
     negativeQuery: Query,
     negativeBoost: Double
-) extends Query
+) extends Query {
+  @deprecated("queryName is not supported in BoostingQuery", "8.18.0")
+  def withQueryName(queryName: String): BoostingQuery = this
+
+  @deprecated("boost is not supported in BoostingQuery", "8.18.0")
+  def boost(boost: Double): BoostingQuery = this
+
+  @deprecated("Use BoostingQuery with required negativeBoost parameter instead", "8.18.0")
+  def negativeBoost(negativeBoost: Double): BoostingQuery = copy(negativeBoost = negativeBoost)
+
+  @deprecated("queryName is not supported in BoostingQuery", "8.18.0")
+  def queryName(queryName: String): BoostingQuery = this
+}
+
+object BoostingQuery {
+  @deprecated("Use BoostingQuery with required negativeBoost parameter instead", "8.18.0")
+  def apply(
+      positiveQuery: Query,
+      negativeQuery: Query
+  ): BoostingQuery =
+    BoostingQuery(positiveQuery, negativeQuery, 1.0D)
+}

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/BoostingQueryTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/queries/BoostingQueryTest.scala
@@ -40,4 +40,18 @@ class BoostingQueryTest extends AnyFlatSpec with Matchers with DockerTests {
       }
     }.await.result.hits.hits.map(_.sourceField("name")) shouldBe Array("helvetica", "verdana", "arial")
   }
+
+  "deprecated boosting query" should "still work" in {
+    client.execute {
+      search("fonts").query {
+        boostingQuery(matchAllQuery(), "verdana").negativeBoost(0.5)
+      }
+    }.await.result.hits.hits.map(_.sourceField("name")) shouldBe Array("helvetica", "arial", "verdana")
+
+    client.execute {
+      search("fonts").query {
+        boostingQuery(matchAllQuery(), "arial").negativeBoost(0.5)
+      }
+    }.await.result.hits.hits.map(_.sourceField("name")) shouldBe Array("helvetica", "verdana", "arial")
+  }
 }


### PR DESCRIPTION
and other deprecated methods. Follows https://github.com/Philippus/elastic4s/pull/3385.