### PR TITLE
Drop scala 2.12.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,29 +11,6 @@ on:
       - series/9.x
 
 jobs:
-  scala-2_12:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout the repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 11
-
-      - name: set up sbt
-        uses: sbt/setup-sbt@v1
-
-      - name: Launch elastic docker
-        uses: ./.github/actions/launch-elasticsearch
-
-      - name: run tests
-        run: sbt ++2.12.20 test
-
   scala-2_13:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,30 +8,6 @@ on:
       - '*.md'
 
 jobs:
-  scala-2_12:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout the repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 11
-
-      - name: set up sbt
-        uses: sbt/setup-sbt@v1
-
-      - name: Launch elastic docker
-        uses: ./.github/actions/launch-elasticsearch
-
-      - name: run tests
-        timeout-minutes: 30
-        run: sbt ++2.12.20 test
-
   scala-2_13:
     runs-on: ubuntu-latest
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -15,11 +15,11 @@ def isRelease              = releaseVersion != ""
 // set by github actions and used as the snapshot build number
 def githubRunNumber = sys.env.getOrElse("GITHUB_RUN_NUMBER", "local")
 
-val scala2Versions   = Seq("2.12.20", "2.13.16")
+val scala2Versions   = Seq("2.13.16")
 val scalaAllVersions = scala2Versions :+ "3.3.5"
 
 lazy val commonScalaVersionSettings = Seq(
-  scalaVersion       := "2.12.20",
+  scalaVersion       := "2.13.16",
   crossScalaVersions := Nil
 )
 


### PR DESCRIPTION
Applying this PR fill drop Scala 2.12.x from the 9.x branch, will keep supporting Scala 2.12.x in the 8.x branch for now. This will enable us to clean up a lot of deprecation warnings. `scala.collection.JavaConverters` =>  `scala.jdk.CollectionConverters` for example.