### PR TITLE
Uniformize params argument in ScriptedMetricAggregation and Script (#3357)

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/ScriptedMetricAggregation.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/ScriptedMetricAggregation.scala
@@ -9,7 +9,7 @@ case class ScriptedMetricAggregation(
     mapScript: Option[Script] = None,
     combineScript: Option[Script] = None,
     reduceScript: Option[Script] = None,
-    params: Map[String, AnyRef] = Map.empty,
+    params: Map[String, Any] = Map.empty,
     subaggs: Seq[AbstractAggregation] = Nil,
     metadata: Map[String, AnyRef] = Map.empty
 ) extends Aggregation {
@@ -21,7 +21,7 @@ case class ScriptedMetricAggregation(
   def combineScript(script: Script): ScriptedMetricAggregation = copy(combineScript = script.some)
   def reduceScript(script: Script): ScriptedMetricAggregation  = copy(reduceScript = script.some)
 
-  def params(params: Map[String, AnyRef]): ScriptedMetricAggregation = copy(params = params)
+  def params(params: Map[String, Any]): ScriptedMetricAggregation = copy(params = params)
 
   override def subAggregations(aggs: Iterable[AbstractAggregation]): T = copy(subaggs = aggs.toSeq)
   override def metadata(map: Map[String, AnyRef]): T                   = copy(metadata = map)


### PR DESCRIPTION
Here are the changes to unitformize params argument in ScriptedMetricAggregation and Script. That's linked to the issue https://github.com/Philippus/elastic4s/issues/3357