### PR TITLE
Fix meta parameter in numeric field types

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ByteField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ByteField.scala
@@ -13,9 +13,9 @@ case class ByteField(
     index: Option[Boolean] = None,
     nullValue: Option[Byte] = None,
     store: Option[Boolean] = None,
+    meta: Map[String, String] = Map.empty,
     timeSeriesDimension: Option[Boolean] = None,
-    timeSeriesMetric: Option[String] = None,
-    meta: Map[String, Any] = Map.empty
+    timeSeriesMetric: Option[String] = None
 ) extends NumberField[Byte] {
   override def `type`: String = ByteField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DoubleField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/DoubleField.scala
@@ -15,8 +15,8 @@ case class DoubleField(
     index: Option[Boolean] = None,
     nullValue: Option[Double] = None,
     store: Option[Boolean] = None,
-    timeSeriesMetric: Option[String] = None,
-    meta: Map[String, Any] = Map.empty
+    meta: Map[String, String] = Map.empty,
+    timeSeriesMetric: Option[String] = None
 ) extends NumberField[Double] {
   override def `type`: String = DoubleField.`type`
 

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/FloatField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/FloatField.scala
@@ -13,8 +13,8 @@ case class FloatField(
     index: Option[Boolean] = None,
     nullValue: Option[Float] = None,
     store: Option[Boolean] = None,
-    timeSeriesMetric: Option[String] = None,
-    meta: Map[String, Any] = Map.empty
+    meta: Map[String, String] = Map.empty,
+    timeSeriesMetric: Option[String] = None
 ) extends NumberField[Float] {
   override def `type`: String = FloatField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/HalfFloatField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/HalfFloatField.scala
@@ -13,8 +13,8 @@ case class HalfFloatField(
     index: Option[Boolean] = None,
     nullValue: Option[Float] = None,
     store: Option[Boolean] = None,
-    timeSeriesMetric: Option[String] = None,
-    meta: Map[String, Any] = Map.empty
+    meta: Map[String, String] = Map.empty,
+    timeSeriesMetric: Option[String] = None
 ) extends NumberField[Float] {
   override def `type`: String = HalfFloatField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/IntegerField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/IntegerField.scala
@@ -15,9 +15,9 @@ case class IntegerField(
     index: Option[Boolean] = None,
     nullValue: Option[Int] = None,
     store: Option[Boolean] = None,
+    meta: Map[String, String] = Map.empty,
     timeSeriesDimension: Option[Boolean] = None,
-    timeSeriesMetric: Option[String] = None,
-    meta: Map[String, Any] = Map.empty
+    timeSeriesMetric: Option[String] = None
 ) extends NumberField[Int] {
   override def `type`: String = IntegerField.`type`
 

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/LongField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/LongField.scala
@@ -13,9 +13,9 @@ case class LongField(
     index: Option[Boolean] = None,
     store: Option[Boolean] = None,
     nullValue: Option[Long] = None,
+    meta: Map[String, String] = Map.empty,
     timeSeriesDimension: Option[Boolean] = None,
-    timeSeriesMetric: Option[String] = None,
-    meta: Map[String, Any] = Map.empty
+    timeSeriesMetric: Option[String] = None
 ) extends NumberField[Long] {
   override def `type`: String = LongField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/NumberField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/NumberField.scala
@@ -9,5 +9,6 @@ trait NumberField[T] extends ElasticField {
   def docValues: Option[Boolean]
   def nullValue: Option[T]
   def copyTo: Seq[String]
+  def meta: Map[String, String]
   def timeSeriesMetric: Option[String]
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ScaledFloatField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ScaledFloatField.scala
@@ -14,8 +14,8 @@ case class ScaledFloatField(
     index: Option[Boolean] = None,
     nullValue: Option[Float] = None,
     store: Option[Boolean] = None,
-    timeSeriesMetric: Option[String] = None,
-    meta: Map[String, Any] = Map.empty
+    meta: Map[String, String] = Map.empty,
+    timeSeriesMetric: Option[String] = None
 ) extends NumberField[Float] {
   override def `type`: String = "scaled_float"
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ShortField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/ShortField.scala
@@ -14,9 +14,9 @@ case class ShortField(
     index: Option[Boolean] = None,
     nullValue: Option[Short] = None,
     store: Option[Boolean] = None,
+    meta: Map[String, String] = Map.empty,
     timeSeriesDimension: Option[Boolean] = None,
-    timeSeriesMetric: Option[String] = None,
-    meta: Map[String, Any] = Map.empty
+    timeSeriesMetric: Option[String] = None
 ) extends NumberField[Short] {
   override def `type`: String = ShortField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/UnsignedLongField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/UnsignedLongField.scala
@@ -13,9 +13,9 @@ case class UnsignedLongField(
     index: Option[Boolean] = None,
     store: Option[Boolean] = None,
     nullValue: Option[Long] = None,
+    meta: Map[String, String] = Map.empty,
     timeSeriesDimension: Option[Boolean] = None,
-    timeSeriesMetric: Option[String] = None,
-    meta: Map[String, Any] = Map.empty
+    timeSeriesMetric: Option[String] = None
 ) extends NumberField[Long] {
   override def `type`: String = UnsignedLongField.`type`
 }

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/UnsignedLongStringField.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/fields/UnsignedLongStringField.scala
@@ -13,9 +13,9 @@ case class UnsignedLongStringField(
     index: Option[Boolean] = None,
     store: Option[Boolean] = None,
     nullValue: Option[String] = None,
+    meta: Map[String, String] = Map.empty,
     timeSeriesDimension: Option[Boolean] = None,
-    timeSeriesMetric: Option[String] = None,
-    meta: Map[String, Any] = Map.empty
+    timeSeriesMetric: Option[String] = None
 ) extends NumberField[String] {
   override def `type`: String = UnsignedLongStringField.`type`
 }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/NumberFieldBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/fields/NumberFieldBuilderFn.scala
@@ -4,7 +4,7 @@ import com.sksamuel.elastic4s.fields._
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 
 object NumberFieldBuilderFn {
-  val supportedTypes = Set(
+  private[fields] val supportedTypes = Set(
     ByteField.`type`,
     DoubleField.`type`,
     FloatField.`type`,
@@ -27,6 +27,7 @@ object NumberFieldBuilderFn {
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.byteValue()),
         values.get("store").map(_.asInstanceOf[Boolean]),
+        values.get("meta").map(_.asInstanceOf[Map[String, String]]).getOrElse(Map.empty),
         values.get("time_series_dimension").map(_.asInstanceOf[Boolean]),
         values.get("time_series_metric").map(_.asInstanceOf[String])
       )
@@ -40,6 +41,7 @@ object NumberFieldBuilderFn {
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.doubleValue()),
         values.get("store").map(_.asInstanceOf[Boolean]),
+        values.get("meta").map(_.asInstanceOf[Map[String, String]]).getOrElse(Map.empty),
         values.get("time_series_metric").map(_.asInstanceOf[String])
       )
     case FloatField.`type`        => FloatField(
@@ -52,6 +54,7 @@ object NumberFieldBuilderFn {
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.floatValue()),
         values.get("store").map(_.asInstanceOf[Boolean]),
+        values.get("meta").map(_.asInstanceOf[Map[String, String]]).getOrElse(Map.empty),
         values.get("time_series_metric").map(_.asInstanceOf[String])
       )
     case HalfFloatField.`type`    => HalfFloatField(
@@ -64,6 +67,7 @@ object NumberFieldBuilderFn {
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.floatValue()),
         values.get("store").map(_.asInstanceOf[Boolean]),
+        values.get("meta").map(_.asInstanceOf[Map[String, String]]).getOrElse(Map.empty),
         values.get("time_series_metric").map(_.asInstanceOf[String])
       )
     case ScaledFloatField.`type`  => ScaledFloatField(
@@ -77,6 +81,7 @@ object NumberFieldBuilderFn {
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.floatValue()),
         values.get("store").map(_.asInstanceOf[Boolean]),
+        values.get("meta").map(_.asInstanceOf[Map[String, String]]).getOrElse(Map.empty),
         values.get("time_series_metric").map(_.asInstanceOf[String])
       )
     case IntegerField.`type`      => IntegerField(
@@ -89,6 +94,7 @@ object NumberFieldBuilderFn {
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.intValue()),
         values.get("store").map(_.asInstanceOf[Boolean]),
+        values.get("meta").map(_.asInstanceOf[Map[String, String]]).getOrElse(Map.empty),
         values.get("time_series_dimension").map(_.asInstanceOf[Boolean]),
         values.get("time_series_metric").map(_.asInstanceOf[String])
       )
@@ -102,6 +108,7 @@ object NumberFieldBuilderFn {
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("store").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.longValue()),
+        values.get("meta").map(_.asInstanceOf[Map[String, String]]).getOrElse(Map.empty),
         values.get("time_series_dimension").map(_.asInstanceOf[Boolean]),
         values.get("time_series_metric").map(_.asInstanceOf[String])
       )
@@ -116,6 +123,7 @@ object NumberFieldBuilderFn {
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.shortValue()),
         values.get("store").map(_.asInstanceOf[Boolean]),
+        values.get("meta").map(_.asInstanceOf[Map[String, String]]).getOrElse(Map.empty),
         values.get("time_series_dimension").map(_.asInstanceOf[Boolean]),
         values.get("time_series_metric").map(_.asInstanceOf[String])
       )
@@ -129,6 +137,7 @@ object NumberFieldBuilderFn {
         values.get("index").map(_.asInstanceOf[Boolean]),
         values.get("store").map(_.asInstanceOf[Boolean]),
         values.get("null_value").map(_.asInstanceOf[Number]).map(_.longValue()),
+        values.get("meta").map(_.asInstanceOf[Map[String, String]]).getOrElse(Map.empty),
         values.get("time_series_dimension").map(_.asInstanceOf[Boolean]),
         values.get("time_series_metric").map(_.asInstanceOf[String])
       )
@@ -162,6 +171,12 @@ object NumberFieldBuilderFn {
       case f: ScaledFloatField =>
         f.scalingFactor.foreach(builder.field("scaling_factor", _))
       case _                   =>
+    }
+
+    if (field.meta.nonEmpty) {
+      builder.startObject("meta")
+      field.meta.foreach { case (key, value) => builder.autofield(key, value) }
+      builder.endObject()
     }
 
     field match {

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/LongFieldTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/fields/LongFieldTest.scala
@@ -17,12 +17,13 @@ class LongFieldTest extends AnyFunSuite with Matchers {
       ignoreMalformed = Some(true),
       index = Some(true),
       copyTo = List("q", "er"),
+      meta = Map("banana" -> "yellow", "strawberry" -> "red"),
       timeSeriesDimension = Some(true),
       timeSeriesMetric = Some("gauge")
     )
 
     val jsonStringValue =
-      """{"type":"long","copy_to":["q","er"],"boost":1.2,"index":true,"null_value":142,"store":true,"coerce":true,"ignore_malformed":true,"time_series_dimension":true,"time_series_metric":"gauge"}"""
+      """{"type":"long","copy_to":["q","er"],"boost":1.2,"index":true,"null_value":142,"store":true,"coerce":true,"ignore_malformed":true,"meta":{"banana":"yellow","strawberry":"red"},"time_series_dimension":true,"time_series_metric":"gauge"}"""
     ElasticFieldBuilderFn(field).string shouldBe jsonStringValue
     ElasticFieldBuilderFn.construct(
       field.name,


### PR DESCRIPTION
Applying this PR will fix the meta parameter in numeric field types:
- change type to `Map[String, String]`, see https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/mapping-field-meta.
- actually use it when rendering to json.
- move the position in front of the time_series-* parameters, for slightly better compatibility with previous releases.