### PR TITLE
feat: supports knn as query

### DIFF
--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/KnnQueryBuilderFnTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/queries/KnnQueryBuilderFnTest.scala
@@ -1,0 +1,18 @@
+package com.sksamuel.elastic4s.requests.searches.queries
+
+import com.sksamuel.elastic4s.handlers.searches.queries.KnnQueryBuilderFn
+import com.sksamuel.elastic4s.requests.searches.knn.Knn
+import com.sksamuel.elastic4s.requests.searches.term.TermQuery
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class KnnQueryBuilderFnTest extends AnyFunSuite with Matchers {
+  test("Knn generates proper query") {
+    val request = Knn("image-vector") numCandidates 50 queryVector Seq(54D, 10D, -2D) k 5 filter TermQuery(
+      "file-type",
+      "png"
+    ) similarity 10 boost .4
+    KnnQueryBuilderFn(request).string shouldBe
+      """{"knn":{"field":"image-vector","filter":{"term":{"file-type":{"value":"png"}}},"k":5,"num_candidates":50,"query_vector":[54.0,10.0,-2.0],"similarity":10.0,"boost":0.4}}""".stripMargin
+  }
+}

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/knn/Knn.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/knn/Knn.scala
@@ -19,7 +19,7 @@ case class Knn(
     boost: Option[Double] = None,
     queryName: Option[String] = None,
     inner: Option[InnerHit] = None
-) {
+) extends Query {
 
   def filter(filter: Query): Knn = copy(filter = filter.some)
 

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/KnnQueryBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/KnnQueryBuilderFn.scala
@@ -1,0 +1,13 @@
+package com.sksamuel.elastic4s.handlers.searches.queries
+
+import com.sksamuel.elastic4s.handlers.searches.knn.KnnBuilderFn
+import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
+import com.sksamuel.elastic4s.requests.searches.knn.Knn
+
+object KnnQueryBuilderFn {
+  def apply(knn: Knn): XContentBuilder = {
+    val builder = XContentFactory.jsonBuilder()
+    builder.rawField("knn", KnnBuilderFn.apply(knn))
+    builder
+  }
+}

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/QueryBuilderFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/searches/queries/QueryBuilderFn.scala
@@ -56,6 +56,7 @@ import com.sksamuel.elastic4s.handlers.searches.queries.text.{
   SimpleStringBodyFn
 }
 import com.sksamuel.elastic4s.json.XContentBuilder
+import com.sksamuel.elastic4s.requests.searches.knn.Knn
 import com.sksamuel.elastic4s.requests.searches.queries.compound.BoolQuery
 import com.sksamuel.elastic4s.requests.searches.queries.funcscorer.FunctionScoreQuery
 import com.sksamuel.elastic4s.requests.searches.queries.geo.{
@@ -181,6 +182,7 @@ object QueryBuilderFn {
     case t: TermsSetQuery          => TermsSetQueryBodyFn(t)
     case q: WildcardQuery          => WildcardQueryBodyFn(q)
     case q: SpanFieldMaskingQuery  => SpanFieldMaskingQueryBodyFn(q)
+    case q: Knn                    => KnnQueryBuilderFn(q)
     case c: CustomQuery            => c.buildQueryBody()
 
     // Not implemented


### PR DESCRIPTION
supports knn as [query](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-knn-query) too 