### PR TITLE
feat: added matched queries to inner hit

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/InnerHit.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/InnerHit.scala
@@ -12,7 +12,8 @@ case class InnerHit(
     innerHits: Map[String, InnerHits],
     highlight: Map[String, Seq[String]],
     sort: Seq[AnyRef],
-    fields: Map[String, AnyRef]
+    fields: Map[String, AnyRef],
+    matchedQueries: Seq[String]
 ) {
 
   def docValueField(fieldName: String): HitField            = docValueFieldOpt(fieldName).get

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchHit.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/searches/SearchHit.scala
@@ -67,7 +67,8 @@ case class SearchHit(
             innerHits = buildInnerHits(hits.getOrElse("inner_hits", null).asInstanceOf[Map[String, Map[String, Any]]]),
             highlight = hits.get("highlight").map(_.asInstanceOf[Map[String, Seq[String]]]).getOrElse(Map.empty),
             sort = hits.get("sort").map(_.asInstanceOf[Seq[AnyRef]]).getOrElse(Seq.empty),
-            fields = hits.get("fields").map(_.asInstanceOf[Map[String, AnyRef]]).getOrElse(Map.empty)
+            fields = hits.get("fields").map(_.asInstanceOf[Map[String, AnyRef]]).getOrElse(Map.empty),
+            matchedQueries = hits.get("matched_queries").map(_.asInstanceOf[Seq[String]]).getOrElse(Seq.empty)
           )
         }
       )

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/InnerHitTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/search/InnerHitTest.scala
@@ -55,7 +55,8 @@ class InnerHitTest extends AnyWordSpec with Matchers with DockerTests {
               Map.empty,
               Map.empty,
               Nil,
-              Map.empty
+              Map.empty,
+              Seq.empty
             )
           )
         )


### PR DESCRIPTION
Added `matchedQueries` to the `InnerHit`. Matched queries cannot just exist in the top level `SearchHit` but also in [Inner Hits](https://www.elastic.co/docs/reference/elasticsearch/rest-apis/retrieve-inner-hits) when having a [Named Query](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-bool-query#named-queries) in a [nested structure](https://www.elastic.co/docs/reference/elasticsearch/mapping-reference/nested). Until now it was not possible to retrieve the matched queries from an inner hit.