### PR TITLE
[series/9.x] add response field to GetTaskResponse

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/task/GetTaskResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/task/GetTaskResponse.scala
@@ -1,3 +1,8 @@
 package com.sksamuel.elastic4s.requests.task
 
-case class GetTaskResponse(completed: Boolean, task: Task, error: Option[TaskError])
+case class GetTaskResponse(
+    completed: Boolean,
+    task: Task,
+    error: Option[TaskError],
+    response: Option[TaskResponse]
+)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/task/TaskFailure.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/task/TaskFailure.scala
@@ -1,0 +1,6 @@
+package com.sksamuel.elastic4s.requests.task
+
+import com.sksamuel.elastic4s.ErrorCause
+
+// https://github.com/elastic/elasticsearch-specification/blob/main/specification/_types/Errors.ts
+case class TaskFailure(index: String, id: String, cause: ErrorCause, status: Int)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/task/TaskResponse.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/task/TaskResponse.scala
@@ -1,0 +1,29 @@
+package com.sksamuel.elastic4s.requests.task
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+import scala.concurrent.duration.{DurationLong, FiniteDuration}
+
+// https://github.com/elastic/elasticsearch-specification/blob/main/specification/_global/reindex/ReindexResponse.ts
+case class TaskResponse(
+    took: Option[Long] = None,
+    @JsonProperty("timed_out") timedOut: Option[Boolean] = None,
+    total: Option[Long] = None,
+    updated: Option[Long] = None,
+    created: Option[Long] = None,
+    deleted: Option[Long] = None,
+    batches: Option[Long] = None,
+    @JsonProperty("version_conflicts") versionConflicts: Option[Long] = None,
+    noops: Option[Long] = None,
+    retries: Option[Retries] = None,
+    throttled: Option[String] = None,
+    @JsonProperty("throttled_millis") throttledMillis: Option[Long] = None,
+    @JsonProperty("requests_per_second") requestsPerSecond: Option[Float] = None,
+    @JsonProperty("throttled_until") throttledUntil: Option[String] = None,
+    @JsonProperty("throttled_until_millis") throttledUntilMillis: Option[Long] = None,
+    task: Option[String] = None,
+    failures: Option[Seq[TaskFailure]] = None
+) {
+  def throttledTime: Option[FiniteDuration]      = throttledMillis.map(_.millis)
+  def throttledUntilTime: Option[FiniteDuration] = throttledUntilMillis.map(_.millis)
+}


### PR DESCRIPTION
Introduced a new optional `response` field to the GetTaskResponse case class to support additional task response details.