### PR TITLE
Add missing endObject in DynamicTemplateBodyFn

### DIFF
--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/mapping/DynamicTemplateBodyFn.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/index/mapping/DynamicTemplateBodyFn.scala
@@ -46,5 +46,6 @@ object DynamicTemplateBodyFn {
     builder.rawField("mapping", ElasticFieldBuilderFn(dyn.mapping))
 
     builder.endObject()
+    builder.endObject()
   }
 }


### PR DESCRIPTION
Applying this PR will fix the unbalanced object closure by adding a missing endObject().