### PR TITLE
Fix hang when queue admission fails before host is assigned

### DIFF
--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
@@ -152,23 +152,29 @@ class AkkaHttpClient private[akka] (
     }
 
     def markDead(): Future[Unit] = {
-      state.host.future
-        .map { host =>
-          if (blacklist.add(host)) {
-            logger.debug(s"added [$host] to blacklist")
-          } else {
-            logger.trace(s"updated [$host] in a blacklist")
+      state.host.future.value match {
+        case Some(Success(host)) =>
+          Future.successful {
+            if (blacklist.add(host)) {
+              logger.debug(s"added [$host] to blacklist")
+            } else {
+              logger.trace(s"updated [$host] in a blacklist")
+            }
           }
-        }
+        case _                   => Future.successful(()) // host is not resolved, nothing to do
+      }
     }
 
     def markAlive(): Future[Unit] = {
-      state.host.future
-        .map { host =>
-          if (blacklist.remove(host)) {
-            logger.debug(s"removed [$host] from blacklist")
-          }
-        }
+      state.host.future.value match {
+        case Some(Success(host)) =>
+          Future.successful(
+            if (blacklist.remove(host)) {
+              logger.debug(s"removed [$host] from blacklist")
+            }
+          )
+        case _                   => Future.successful(()) // host is not resolved, nothing to do
+      }
     }
 
     queueRequest(request, state)

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
@@ -1,7 +1,9 @@
 package com.sksamuel.elastic4s.akka
 
+import akka.NotUsed
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes, Uri}
+import akka.stream.scaladsl.Flow
 import com.sksamuel.elastic4s.{ElasticRequest, HttpEntity => ElasticEntity, HttpResponse => ElasticResponse}
 import org.mockito.ArgumentMatchers._
 import org.scalatest.BeforeAndAfterAll
@@ -32,6 +34,16 @@ class AkkaHttpClientMockTest
     val sendRequest = mock[Function[HttpRequest, Try[HttpResponse]]]
     val poolFactory = new TestHttpPoolFactory(sendRequest)
     (sendRequest, poolFactory)
+  }
+
+  private class ClosedPoolFactory extends HttpPoolFactory {
+    override def create[T](): Flow[(HttpRequest, T), (HttpRequest, Try[HttpResponse], T), NotUsed] =
+      Flow[(HttpRequest, T)]
+        .take(0)
+        .map { case (r, s) => (r, Success(HttpResponse()), s) }
+
+    override def shutdown(): scala.concurrent.Future[Unit] =
+      scala.concurrent.Future.successful(())
   }
 
   "AkkaHttpClient" should {
@@ -218,5 +230,21 @@ class AkkaHttpClientMockTest
       )
     }
 
+    "not hang when queue offer fails before host is resolved" in {
+      val blacklist = mock[Blacklist]
+
+      val client = new AkkaHttpClient(
+        AkkaHttpClientSettings(List("host1")).copy(maxRetryTimeout = 0.seconds),
+        blacklist,
+        new ClosedPoolFactory
+      )
+
+      val err = client
+        .send(ElasticRequest("GET", "/test"))
+        .failed
+        .futureValue
+      err.getMessage should include("Request retries exceeded max retry timeout")
+      verify(blacklist, never()).add(any[String])
+    }
   }
 }

--- a/elastic4s-client-pekko/src/main/scala/com/sksamuel/elastic4s/pekko/PekkoHttpClient.scala
+++ b/elastic4s-client-pekko/src/main/scala/com/sksamuel/elastic4s/pekko/PekkoHttpClient.scala
@@ -152,23 +152,29 @@ class PekkoHttpClient private[pekko] (
     }
 
     def markDead(): Future[Unit] = {
-      state.host.future
-        .map { host =>
-          if (blacklist.add(host)) {
-            logger.debug(s"added [$host] to blacklist")
-          } else {
-            logger.trace(s"updated [$host] in a blacklist")
+      state.host.future.value match {
+        case Some(Success(host)) =>
+          Future.successful {
+            if (blacklist.add(host)) {
+              logger.debug(s"added [$host] to blacklist")
+            } else {
+              logger.trace(s"updated [$host] in a blacklist")
+            }
           }
-        }
+        case _                   => Future.successful(()) // host is not resolved, nothing to do
+      }
     }
 
     def markAlive(): Future[Unit] = {
-      state.host.future
-        .map { host =>
-          if (blacklist.remove(host)) {
-            logger.debug(s"removed [$host] from blacklist")
-          }
-        }
+      state.host.future.value match {
+        case Some(Success(host)) =>
+          Future.successful(
+            if (blacklist.remove(host)) {
+              logger.debug(s"removed [$host] from blacklist")
+            }
+          )
+        case _                   => Future.successful(()) // host is not resolved, nothing to do
+      }
     }
 
     queueRequest(request, state)

--- a/elastic4s-client-pekko/src/test/scala/com/sksamuel/elastic4s/pekko/PekkoHttpClientMockTest.scala
+++ b/elastic4s-client-pekko/src/test/scala/com/sksamuel/elastic4s/pekko/PekkoHttpClientMockTest.scala
@@ -1,7 +1,9 @@
 package com.sksamuel.elastic4s.pekko
 
+import org.apache.pekko.NotUsed
 import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes, Uri}
+import org.apache.pekko.stream.scaladsl.Flow
 import com.sksamuel.elastic4s.{ElasticRequest, HttpEntity => ElasticEntity, HttpResponse => ElasticResponse}
 import org.mockito.ArgumentMatchers._
 import org.scalatest.BeforeAndAfterAll
@@ -32,6 +34,16 @@ class PekkoHttpClientMockTest
     val sendRequest = mock[Function[HttpRequest, Try[HttpResponse]]]
     val poolFactory = new TestHttpPoolFactory(sendRequest)
     (sendRequest, poolFactory)
+  }
+
+  private class ClosedPoolFactory extends HttpPoolFactory {
+    override def create[T](): Flow[(HttpRequest, T), (HttpRequest, Try[HttpResponse], T), NotUsed] =
+      Flow[(HttpRequest, T)]
+        .take(0)
+        .map { case (r, s) => (r, Success(HttpResponse()), s) }
+
+    override def shutdown(): scala.concurrent.Future[Unit] =
+      scala.concurrent.Future.successful(())
   }
 
   "PekkoHttpClient" should {
@@ -216,6 +228,23 @@ class PekkoHttpClientMockTest
         Some(ElasticEntity.StringEntity("host2", None)),
         Map.empty
       )
+    }
+
+    "not hang when queue offer fails before host is resolved" in {
+      val blacklist = mock[Blacklist]
+
+      val client = new PekkoHttpClient(
+        PekkoHttpClientSettings(List("host1")).copy(maxRetryTimeout = 0.seconds),
+        blacklist,
+        new ClosedPoolFactory
+      )
+
+      val err = client
+        .send(ElasticRequest("GET", "/test"))
+        .failed
+        .futureValue
+      err.getMessage should include("Request retries exceeded max retry timeout")
+      verify(blacklist, never()).add(any[String])
     }
 
   }


### PR DESCRIPTION
This PR fixes a hang in ElasticClient.execute under high concurrency for elastic4s-client-akka and elastic4s-client-pekko when queue admission fails before a host is assigned.
When queue.offer(...) fails early, request recovery currently calls markDead(), which waits on RequestState.host.future. In this path, host is never completed (it is only completed later in the stream), so recovery can stall indefinitely.
This change makes host-marking logic non-blocking when host resolution has not happened yet, preventing deadlock and allowing normal retry/timeout behavior.
What changed
1. Updated AkkaHttpClient and PekkoHttpClient:
  ◦markDead() and markAlive() now check whether state.host is already resolved.
  ◦ If host is unresolved, they complete immediately (no-op) instead of waiting on state.host.future.
2. Added regression tests in both mock test suites to cover queue-offer failure before host resolution and assert:
  ◦ request fails with retry-timeout semantics (no hang),
  ◦ blacklist is not incorrectly updated when host is unknown.

Why this is safe
• Existing blacklist behavior is preserved for requests where a host is actually selected.
• Only the pre-host-failure path changes, replacing an indefinite wait with deterministic completion..

Fixes https://github.com/Philippus/elastic4s/issues/3493.