### PR TITLE
Fix premature completion in ElasticSource

### DIFF
--- a/elastic4s-streams-akka/src/main/scala/com/sksamuel/elastic4s/akka/streams/ElasticSource.scala
+++ b/elastic4s-streams-akka/src/main/scala/com/sksamuel/elastic4s/akka/streams/ElasticSource.scala
@@ -36,15 +36,13 @@ class ElasticSource(client: ElasticClient[Future], settings: SourceSettings)(imp
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with OutHandler {
 
-      private val buffer           = scala.collection.mutable.Queue.empty[SearchHit]
-      private var scrollId: String = _
-      private var fetching         = false
+      private val buffer            = scala.collection.mutable.Queue.empty[SearchHit]
+      private var scrollId: String  = _
+      private var fetching          = false
+      private var upstreamExhausted = false
 
       // Parse the keep alive setting out of the original query.
       private val keepAlive = settings.search.keepAlive.map(_.toString).getOrElse("1m")
-
-      if (settings.warm)
-        fetch()
 
       private val populateHandler = getAsyncCallback[Try[Response[SearchResponse]]] {
         case Failure(e)        => fail(out, e)
@@ -56,28 +54,36 @@ class ElasticSource(client: ElasticClient[Future], settings: SourceSettings)(imp
                 case Some(id) =>
                   scrollId = id
                   fetching = false
-                  buffer ++= searchr.hits.hits
+                  val hits = searchr.hits.hits
+                  if (hits.isEmpty) upstreamExhausted = true
+                  else buffer ++= hits
                   if (buffer.nonEmpty && isAvailable(out)) {
                     push(out, buffer.dequeue())
-                    maybeFetch()
                   }
-                  // complete when no more elements to emit
-                  if (searchr.hits.hits.length == 0) {
-                    complete(out)
-                  }
+                  maybeFetch()
+                  maybeComplete()
               }
           }
       }
 
+      override def preStart(): Unit = {
+        if (settings.warm) fetch()
+      }
+
+      private def maybeComplete(): Unit = {
+        if (upstreamExhausted && buffer.isEmpty && !fetching)
+          complete(out)
+      }
+
       // check if the buffer has dropped below threshold (or is empty) and if so, trigger a fetch
       private def maybeFetch(): Unit = {
-        if (buffer.isEmpty || buffer.size <= settings.fetchThreshold)
+        if (!upstreamExhausted && (buffer.isEmpty || buffer.size <= settings.fetchThreshold))
           fetch()
       }
 
       // if no fetch is in progress then fire one
       private def fetch(): Unit = {
-        if (!fetching) {
+        if (!fetching && !upstreamExhausted) {
           Option(scrollId) match {
             case None     => client.execute(settings.search).onComplete(populateHandler.invoke)
             case Some(id) => client.execute(searchScroll(id).keepAlive(keepAlive)).onComplete(populateHandler.invoke)
@@ -90,6 +96,7 @@ class ElasticSource(client: ElasticClient[Future], settings: SourceSettings)(imp
         if (buffer.nonEmpty)
           push(out, buffer.dequeue())
         maybeFetch()
+        maybeComplete()
       }
 
       override def postStop(): Unit = {

--- a/elastic4s-streams-akka/src/test/scala/com/sksamuel/elastic4s/akka/streams/ElasticSourceTest.scala
+++ b/elastic4s-streams-akka/src/test/scala/com/sksamuel/elastic4s/akka/streams/ElasticSourceTest.scala
@@ -1,0 +1,180 @@
+package com.sksamuel.elastic4s.akka.streams
+
+import akka.actor.ActorSystem
+import akka.stream.scaladsl.{Sink, Source}
+import com.sksamuel.elastic4s.ElasticDsl.search
+import com.sksamuel.elastic4s.requests.common.Shards
+import com.sksamuel.elastic4s.requests.searches._
+import com.sksamuel.elastic4s.{
+  CommonRequestOptions,
+  ElasticClient,
+  ElasticRequest,
+  Handler,
+  HttpClient,
+  HttpResponse,
+  RequestSuccess,
+  Response
+}
+import org.reactivestreams.{Subscriber, Subscription}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
+
+class ElasticSourceTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  private implicit val system: ActorSystem                        = ActorSystem(getClass.getSimpleName)
+  private implicit val ec: ExecutionContext                       = system.dispatcher
+  private implicit val commonRequestOptions: CommonRequestOptions = CommonRequestOptions.defaults
+
+  override protected def afterAll(): Unit =
+    Await.result(system.terminate(), 10.seconds)
+
+  "ElasticSource" should {
+    "not complete while buffered hits remain after an empty prefetched scroll page" in {
+      val page1     = (1 to 5).map(i => hit(i.toString)).toArray
+      val responses = Vector(
+        RequestSuccess(200, None, Map.empty, response("scroll-1", page1)),
+        RequestSuccess(200, None, Map.empty, response("scroll-1", Array.empty))
+      )
+
+      val client   = scriptedClient(responses)
+      val settings = SourceSettings(
+        search("test-index").scroll("1m").size(5),
+        maxItems = Long.MaxValue,
+        fetchThreshold = 4,
+        warm = false
+      )
+
+      val publisher = Source
+        .fromGraph(new ElasticSource(client, settings))
+        .runWith(Sink.asPublisher(fanout = false))
+
+      val sub = new ManualSubscriber[SearchHit]
+      publisher.subscribe(sub)
+
+      sub.awaitSubscribed(1000) shouldBe true
+
+      sub.request(1)
+      sub.awaitElements(1, 2000) shouldBe true
+
+      // Old behavior completes early here; fixed behavior must not complete yet.
+      sub.completedWithin(300) shouldBe false
+
+      sub.request(10)
+      sub.completedWithin(3000) shouldBe true
+      sub.error shouldBe null
+      sub.items.map(_.id) should contain theSameElementsInOrderAs page1.map(_.id).toSeq
+    }
+  }
+
+  private def scriptedClient(
+      pages: Vector[RequestSuccess[SearchResponse]]
+  ): ElasticClient[Future] = {
+    val index = new AtomicInteger(0)
+
+    new ElasticClient[Future](new HttpClient[Future] {
+      override def send(request: ElasticRequest): Future[HttpResponse] =
+        Future.failed(new UnsupportedOperationException("Not used in this test"))
+      override def close(): Future[Unit]                               = Future.successful(())
+    }) {
+      override def execute[T, U](t: T)(implicit
+          handler: Handler[T, U],
+          options: CommonRequestOptions
+      ): Future[Response[U]] =
+        t match {
+          case _: SearchRequest | _: SearchScrollRequest =>
+            val i    = index.getAndIncrement()
+            val next =
+              if (i < pages.length) pages(i)
+              else RequestSuccess(200, None, Map.empty, response("scroll-1", Array.empty))
+            Future.successful(next.asInstanceOf[Response[U]])
+          case _: ClearScrollRequest                     =>
+            Future.successful(
+              RequestSuccess(200, None, Map.empty, ClearScrollResponse(succeeded = true, num_freed = 1).asInstanceOf[U])
+            )
+          case other                                     =>
+            Future.failed(new IllegalArgumentException(s"Unexpected request type: ${other.getClass.getName}"))
+        }
+    }
+  }
+
+  private def response(scrollId: String, hits: Array[SearchHit]): SearchResponse =
+    SearchResponse(
+      took = 1,
+      isTimedOut = false,
+      isTerminatedEarly = false,
+      suggest = Map.empty,
+      _shards = Shards(1, 1, 0),
+      scrollId = Some(scrollId),
+      pitId = None,
+      _aggregationsAsMap = Map.empty,
+      hits = SearchHits(Total(hits.length.toLong, "eq"), maxScore = 1.0, hits = hits)
+    )
+
+  private def hit(id: String): SearchHit =
+    SearchHit(
+      id = id,
+      index = "test-index",
+      version = 1L,
+      seqNo = 0L,
+      primaryTerm = 1L,
+      score = 1.0F,
+      parent = None,
+      shard = None,
+      node = None,
+      routing = None,
+      explanation = None,
+      sort = None,
+      _source = Map("id" -> id),
+      fields = Map.empty,
+      _highlight = None,
+      inner_hits = Map.empty,
+      matchedQueries = None
+    )
+}
+
+private final class ManualSubscriber[T] extends Subscriber[T] {
+  private val subscribed                  = new CountDownLatch(1)
+  private val done                        = new CountDownLatch(1)
+  private val err                         = new AtomicReference[Throwable](null)
+  private val q                           = new ConcurrentLinkedQueue[T]()
+  @volatile private var sub: Subscription = _
+
+  override def onSubscribe(s: Subscription): Unit = {
+    sub = s
+    subscribed.countDown()
+  }
+
+  override def onNext(t: T): Unit = q.add(t)
+
+  override def onError(t: Throwable): Unit = {
+    err.set(t)
+    done.countDown()
+  }
+
+  override def onComplete(): Unit = done.countDown()
+
+  def awaitSubscribed(timeoutMs: Long): Boolean =
+    subscribed.await(timeoutMs, TimeUnit.MILLISECONDS)
+
+  def request(n: Long): Unit = sub.request(n)
+
+  def items: Vector[T] = q.iterator().asScala.toVector
+
+  def awaitElements(atLeast: Int, timeoutMs: Long): Boolean = {
+    val deadline = System.nanoTime() + timeoutMs * 1000000L
+    while (items.size < atLeast && System.nanoTime() < deadline) Thread.sleep(10)
+    items.size >= atLeast
+  }
+
+  def completedWithin(timeoutMs: Long): Boolean =
+    done.await(timeoutMs, TimeUnit.MILLISECONDS)
+
+  def error: Throwable = err.get()
+}

--- a/elastic4s-streams-pekko/src/main/scala/com/sksamuel/elastic4s/pekko/streams/ElasticSource.scala
+++ b/elastic4s-streams-pekko/src/main/scala/com/sksamuel/elastic4s/pekko/streams/ElasticSource.scala
@@ -37,15 +37,13 @@ class ElasticSource(client: ElasticClient[Future], settings: SourceSettings)(imp
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with OutHandler {
 
-      private val buffer           = scala.collection.mutable.Queue.empty[SearchHit]
-      private var scrollId: String = _
-      private var fetching         = false
+      private val buffer            = scala.collection.mutable.Queue.empty[SearchHit]
+      private var scrollId: String  = _
+      private var fetching          = false
+      private var upstreamExhausted = false
 
       // Parse the keep alive setting out of the original query.
       private val keepAlive = settings.search.keepAlive.map(_.toString).getOrElse("1m")
-
-      if (settings.warm)
-        fetch()
 
       private val populateHandler = getAsyncCallback[Try[Response[SearchResponse]]] {
         case Failure(e)        => fail(out, e)
@@ -57,28 +55,36 @@ class ElasticSource(client: ElasticClient[Future], settings: SourceSettings)(imp
                 case Some(id) =>
                   scrollId = id
                   fetching = false
-                  buffer ++= searchr.hits.hits
+                  val hits = searchr.hits.hits
+                  if (hits.isEmpty) upstreamExhausted = true
+                  else buffer ++= hits
                   if (buffer.nonEmpty && isAvailable(out)) {
                     push(out, buffer.dequeue())
-                    maybeFetch()
                   }
-                  // complete when no more elements to emit
-                  if (searchr.hits.hits.length == 0) {
-                    complete(out)
-                  }
+                  maybeFetch()
+                  maybeComplete()
               }
           }
       }
 
+      override def preStart(): Unit = {
+        if (settings.warm) fetch()
+      }
+
+      private def maybeComplete(): Unit = {
+        if (upstreamExhausted && buffer.isEmpty && !fetching)
+          complete(out)
+      }
+
       // check if the buffer has dropped below threshold (or is empty) and if so, trigger a fetch
       private def maybeFetch(): Unit = {
-        if (buffer.isEmpty || buffer.size <= settings.fetchThreshold)
+        if (!upstreamExhausted && (buffer.isEmpty || buffer.size <= settings.fetchThreshold))
           fetch()
       }
 
       // if no fetch is in progress then fire one
       private def fetch(): Unit = {
-        if (!fetching) {
+        if (!fetching && !upstreamExhausted) {
           Option(scrollId) match {
             case None     => client.execute(settings.search).onComplete(populateHandler.invoke)
             case Some(id) => client.execute(searchScroll(id).keepAlive(keepAlive)).onComplete(populateHandler.invoke)
@@ -91,6 +97,7 @@ class ElasticSource(client: ElasticClient[Future], settings: SourceSettings)(imp
         if (buffer.nonEmpty)
           push(out, buffer.dequeue())
         maybeFetch()
+        maybeComplete()
       }
 
       override def postStop(): Unit = {

--- a/elastic4s-streams-pekko/src/test/scala/com/sksamuel/elastic4s/pekko/streams/ElasticSourceTest/ElasticSourceTest.scala
+++ b/elastic4s-streams-pekko/src/test/scala/com/sksamuel/elastic4s/pekko/streams/ElasticSourceTest/ElasticSourceTest.scala
@@ -1,0 +1,180 @@
+package com.sksamuel.elastic4s.pekko.streams
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.{Sink, Source}
+import com.sksamuel.elastic4s.ElasticDsl.search
+import com.sksamuel.elastic4s.requests.common.Shards
+import com.sksamuel.elastic4s.requests.searches._
+import com.sksamuel.elastic4s.{
+  CommonRequestOptions,
+  ElasticClient,
+  ElasticRequest,
+  Handler,
+  HttpClient,
+  HttpResponse,
+  RequestSuccess,
+  Response
+}
+import org.reactivestreams.{Subscriber, Subscription}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
+import java.util.concurrent.{ConcurrentLinkedQueue, CountDownLatch, TimeUnit}
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.jdk.CollectionConverters._
+
+class ElasticSourceTest extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  private implicit val system: ActorSystem                        = ActorSystem(getClass.getSimpleName)
+  private implicit val ec: ExecutionContext                       = system.dispatcher
+  private implicit val commonRequestOptions: CommonRequestOptions = CommonRequestOptions.defaults
+
+  override protected def afterAll(): Unit =
+    Await.result(system.terminate(), 10.seconds)
+
+  "ElasticSource" should {
+    "not complete while buffered hits remain after an empty prefetched scroll page" in {
+      val page1     = (1 to 5).map(i => hit(i.toString)).toArray
+      val responses = Vector(
+        RequestSuccess(200, None, Map.empty, response("scroll-1", page1)),
+        RequestSuccess(200, None, Map.empty, response("scroll-1", Array.empty))
+      )
+
+      val client   = scriptedClient(responses)
+      val settings = SourceSettings(
+        search("test-index").scroll("1m").size(5),
+        maxItems = Long.MaxValue,
+        fetchThreshold = 4,
+        warm = false
+      )
+
+      val publisher = Source
+        .fromGraph(new ElasticSource(client, settings))
+        .runWith(Sink.asPublisher(fanout = false))
+
+      val sub = new ManualSubscriber[SearchHit]
+      publisher.subscribe(sub)
+
+      sub.awaitSubscribed(1000) shouldBe true
+
+      sub.request(1)
+      sub.awaitElements(1, 2000) shouldBe true
+
+      // Old behavior completes early here; fixed behavior must not complete yet.
+      sub.completedWithin(300) shouldBe false
+
+      sub.request(10)
+      sub.completedWithin(3000) shouldBe true
+      sub.error shouldBe null
+      sub.items.map(_.id) should contain theSameElementsInOrderAs page1.map(_.id).toSeq
+    }
+  }
+
+  private def scriptedClient(
+      pages: Vector[RequestSuccess[SearchResponse]]
+  ): ElasticClient[Future] = {
+    val index = new AtomicInteger(0)
+
+    new ElasticClient[Future](new HttpClient[Future] {
+      override def send(request: ElasticRequest): Future[HttpResponse] =
+        Future.failed(new UnsupportedOperationException("Not used in this test"))
+      override def close(): Future[Unit]                               = Future.successful(())
+    }) {
+      override def execute[T, U](t: T)(implicit
+          handler: Handler[T, U],
+          options: CommonRequestOptions
+      ): Future[Response[U]] =
+        t match {
+          case _: SearchRequest | _: SearchScrollRequest =>
+            val i    = index.getAndIncrement()
+            val next =
+              if (i < pages.length) pages(i)
+              else RequestSuccess(200, None, Map.empty, response("scroll-1", Array.empty))
+            Future.successful(next.asInstanceOf[Response[U]])
+          case _: ClearScrollRequest                     =>
+            Future.successful(
+              RequestSuccess(200, None, Map.empty, ClearScrollResponse(succeeded = true, num_freed = 1).asInstanceOf[U])
+            )
+          case other                                     =>
+            Future.failed(new IllegalArgumentException(s"Unexpected request type: ${other.getClass.getName}"))
+        }
+    }
+  }
+
+  private def response(scrollId: String, hits: Array[SearchHit]): SearchResponse =
+    SearchResponse(
+      took = 1,
+      isTimedOut = false,
+      isTerminatedEarly = false,
+      suggest = Map.empty,
+      _shards = Shards(1, 1, 0),
+      scrollId = Some(scrollId),
+      pitId = None,
+      _aggregationsAsMap = Map.empty,
+      hits = SearchHits(Total(hits.length.toLong, "eq"), maxScore = 1.0, hits = hits)
+    )
+
+  private def hit(id: String): SearchHit =
+    SearchHit(
+      id = id,
+      index = "test-index",
+      version = 1L,
+      seqNo = 0L,
+      primaryTerm = 1L,
+      score = 1.0F,
+      parent = None,
+      shard = None,
+      node = None,
+      routing = None,
+      explanation = None,
+      sort = None,
+      _source = Map("id" -> id),
+      fields = Map.empty,
+      _highlight = None,
+      inner_hits = Map.empty,
+      matchedQueries = None
+    )
+}
+
+private final class ManualSubscriber[T] extends Subscriber[T] {
+  private val subscribed                  = new CountDownLatch(1)
+  private val done                        = new CountDownLatch(1)
+  private val err                         = new AtomicReference[Throwable](null)
+  private val q                           = new ConcurrentLinkedQueue[T]()
+  @volatile private var sub: Subscription = _
+
+  override def onSubscribe(s: Subscription): Unit = {
+    sub = s
+    subscribed.countDown()
+  }
+
+  override def onNext(t: T): Unit = q.add(t)
+
+  override def onError(t: Throwable): Unit = {
+    err.set(t)
+    done.countDown()
+  }
+
+  override def onComplete(): Unit = done.countDown()
+
+  def awaitSubscribed(timeoutMs: Long): Boolean =
+    subscribed.await(timeoutMs, TimeUnit.MILLISECONDS)
+
+  def request(n: Long): Unit = sub.request(n)
+
+  def items: Vector[T] = q.iterator().asScala.toVector
+
+  def awaitElements(atLeast: Int, timeoutMs: Long): Boolean = {
+    val deadline = System.nanoTime() + timeoutMs * 1000000L
+    while (items.size < atLeast && System.nanoTime() < deadline) Thread.sleep(10)
+    items.size >= atLeast
+  }
+
+  def completedWithin(timeoutMs: Long): Boolean =
+    done.await(timeoutMs, TimeUnit.MILLISECONDS)
+
+  def error: Throwable = err.get()
+}


### PR DESCRIPTION
ElasticSource completed immediately when a scroll response returned 0 hits. With fetchThreshold > 0, an empty prefetched page can arrive while previously fetched hits are still buffered, causing early stream completion and silent data loss.

changes:
1. Moved warm-up fetch to preStart() so async callbacks are initialized before any fetch starts.
2. Added an upstreamExhausted state to mark that scroll has no more pages.
3. Changed completion logic to complete only when:
  - upstream is exhausted, and
  - buffer is empty, and
  - no fetch is in flight.
4. Prevented additional fetches after exhaustion.
5. Applied the same fix to both Akka and Pekko ElasticSource implementations.
6. Added deterministic regression tests (manual subscriber / controlled demand) that verify:
• the stream does not complete while buffered hits remain after an empty prefetched scroll response,
• all buffered hits are emitted before completion.

These tests fail with the old behavior and pass with this fix.

Fixes https://github.com/Philippus/elastic4s/issues/3596.