### PR TITLE
Fix size- and list-methods in DefaultBlackList

### DIFF
--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/DefaultBlacklist.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/DefaultBlacklist.scala
@@ -53,22 +53,36 @@ private[akka] class DefaultBlacklist(min: FiniteDuration, max: FiniteDuration, n
     hosts.remove(host) != null
   }
 
+  private def isActive(host: String, record: BlacklistRecord, now: Long): Boolean = {
+    if (!record.enabled)
+      false
+    else if (now - record.untilTime >= 0) {
+      hosts.put(host, record.copy(enabled = false))
+      false
+    } else
+      true
+  }
+
   override def contains(host: String): Boolean = {
+    val now = nanoTime
     hosts.get(host) match {
       case null => false
-      case r    =>
-        if (r.enabled) {
-          if (nanoTime - r.untilTime >= 0) {
-            hosts.put(host, r.copy(enabled = false))
-            false
-          } else true
-        } else false
+      case r    => isActive(host, r, now)
     }
   }
 
-  override def size: Int = hosts.size()
+  override def size: Int = {
+    val now = nanoTime
+    hosts.entrySet().asScala.count(entry => isActive(entry.getKey, entry.getValue, now))
+  }
 
-  override def list: List[String] = hosts.keys().asScala.toList
+  override def list: List[String] = {
+    val now = nanoTime
+    hosts.entrySet().asScala.toList.collect {
+      case entry if isActive(entry.getKey, entry.getValue, now) =>
+        entry.getKey
+    }
+  }
 }
 
 object DefaultBlacklist {

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/DefaultBlacklistTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/DefaultBlacklistTest.scala
@@ -80,5 +80,35 @@ class DefaultBlacklistTest extends AnyWordSpec with Matchers {
       now = minDuration.toNanos
       blacklist.contains(host) shouldBe false
     }
+
+    "count only currently blacklisted hosts in size" in {
+      var now: Long = 0
+      val host2     = "elastic2.test"
+      val blacklist = new DefaultBlacklist(minDuration, maxDuration, now)
+
+      blacklist.add(host)
+      blacklist.size shouldBe 1
+
+      now = minDuration.toNanos
+      blacklist.add(host2)
+
+      blacklist.size shouldBe 1
+      blacklist.contains(host) shouldBe false
+      blacklist.contains(host2) shouldBe true
+    }
+
+    "list only currently blacklisted hosts" in {
+      var now: Long = 0
+      val host2     = "elastic2.test"
+      val blacklist = new DefaultBlacklist(minDuration, maxDuration, now)
+
+      blacklist.add(host)
+      blacklist.list should contain theSameElementsAs List(host)
+
+      now += minDuration.toNanos
+      blacklist.add(host2)
+
+      blacklist.list should contain theSameElementsAs List(host2)
+    }
   }
 }

--- a/elastic4s-client-pekko/src/main/scala/com/sksamuel/elastic4s/pekko/DefaultBlacklist.scala
+++ b/elastic4s-client-pekko/src/main/scala/com/sksamuel/elastic4s/pekko/DefaultBlacklist.scala
@@ -53,22 +53,36 @@ private[pekko] class DefaultBlacklist(min: FiniteDuration, max: FiniteDuration, 
     hosts.remove(host) != null
   }
 
+  private def isActive(host: String, record: BlacklistRecord, now: Long): Boolean = {
+    if (!record.enabled)
+      false
+    else if (now - record.untilTime >= 0) {
+      hosts.put(host, record.copy(enabled = false))
+      false
+    } else
+      true
+  }
+
   override def contains(host: String): Boolean = {
+    val now = nanoTime
     hosts.get(host) match {
       case null => false
-      case r    =>
-        if (r.enabled) {
-          if (nanoTime - r.untilTime >= 0) {
-            hosts.put(host, r.copy(enabled = false))
-            false
-          } else true
-        } else false
+      case r    => isActive(host, r, now)
     }
   }
 
-  override def size: Int = hosts.size()
+  override def size: Int = {
+    val now = nanoTime
+    hosts.entrySet().asScala.count(entry => isActive(entry.getKey, entry.getValue, now))
+  }
 
-  override def list: List[String] = hosts.keys().asScala.toList
+  override def list: List[String] = {
+    val now = nanoTime
+    hosts.entrySet().asScala.toList.collect {
+      case entry if isActive(entry.getKey, entry.getValue, now) =>
+        entry.getKey
+    }
+  }
 }
 
 object DefaultBlacklist {

--- a/elastic4s-client-pekko/src/test/scala/com/sksamuel/elastic4s/pekko/DefaultBlacklistTest.scala
+++ b/elastic4s-client-pekko/src/test/scala/com/sksamuel/elastic4s/pekko/DefaultBlacklistTest.scala
@@ -80,5 +80,35 @@ class DefaultBlacklistTest extends AnyWordSpec with Matchers {
       now = minDuration.toNanos
       blacklist.contains(host) shouldBe false
     }
+
+    "count only currently blacklisted hosts in size" in {
+      var now: Long = 0
+      val host2     = "elastic2.test"
+      val blacklist = new DefaultBlacklist(minDuration, maxDuration, now)
+
+      blacklist.add(host)
+      blacklist.size shouldBe 1
+
+      now = minDuration.toNanos
+      blacklist.add(host2)
+
+      blacklist.size shouldBe 1
+      blacklist.contains(host) shouldBe false
+      blacklist.contains(host2) shouldBe true
+    }
+
+    "list only currently blacklisted hosts" in {
+      var now: Long = 0
+      val host2     = "elastic2.test"
+      val blacklist = new DefaultBlacklist(minDuration, maxDuration, now)
+
+      blacklist.add(host)
+      blacklist.list should contain theSameElementsAs List(host)
+
+      now += minDuration.toNanos
+      blacklist.add(host2)
+
+      blacklist.list should contain theSameElementsAs List(host2)
+    }
   }
 }


### PR DESCRIPTION
Applying this PR will fix the `size`- and `list`-methods in `DefaultBlackList`. Just like the `contains`-method they should check for activity first.