### PR TITLE
Retry with delay if all hosts are blacklisted

### DIFF
--- a/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
+++ b/elastic4s-client-akka/src/main/scala/com/sksamuel/elastic4s/akka/AkkaHttpClient.scala
@@ -4,18 +4,17 @@ import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{BasicHttpCredentials, RawHeader}
+import akka.pattern.after
 import akka.stream.scaladsl.{FileIO, Keep, Sink, Source, StreamConverters}
 import akka.stream.{Materializer, OverflowStrategy, QueueOfferResult}
 import akka.util.ByteString
 import com.sksamuel.elastic4s.HttpEntity.StringEntity
 import com.sksamuel.elastic4s.{
-  ElasticRequest,
-  HttpClient => ElasticHttpClient,
-  HttpEntity => ElasticHttpEntity,
-  HttpResponse => ElasticHttpResponse
+  ElasticRequest, HttpClient => ElasticHttpClient, HttpEntity => ElasticHttpEntity, HttpResponse => ElasticHttpResponse
 }
 
 import scala.concurrent.{Future, Promise}
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 class AkkaHttpClient private[akka] (
@@ -129,13 +128,24 @@ class AkkaHttpClient private[akka] (
 
     val state = RequestState()
 
+    val allHostsBlacklistedRetryDelay = 100.millis
+
     def retryIfPossible(
         notPossible: => Either[Throwable, ElasticHttpResponse]
     ): Future[ElasticHttpResponse] = {
-      val timePassed = System.nanoTime - startTimeNanos
+      val timePassed        = System.nanoTime - startTimeNanos
+      val hasAvailableHosts = settings.hosts.exists(host => !blacklist.contains(host))
+
       if (timePassed < settings.maxRetryTimeout.toNanos) {
-        logger.trace(s"Retrying a request: ${request.endpoint}")
-        queueRequestWithRetry(request, startTimeNanos)
+        if (hasAvailableHosts) {
+          logger.trace(s"Retrying a request immediately: ${request.endpoint}")
+          queueRequestWithRetry(request, startTimeNanos)
+        } else {
+          logger.trace(s"All hosts blacklisted, retrying with delay: ${request.endpoint}")
+          after(allHostsBlacklistedRetryDelay, system.scheduler) {
+            queueRequestWithRetry(request, startTimeNanos)
+          }
+        }
       } else {
         notPossible match {
           case Left(exc)   =>

--- a/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
+++ b/elastic4s-client-akka/src/test/scala/com/sksamuel/elastic4s/akka/AkkaHttpClientMockTest.scala
@@ -124,6 +124,47 @@ class AkkaHttpClientMockTest
       )
     }
 
+    "retry with delay when all hosts are blacklisted" in {
+
+      val hosts                   = List("host1")
+      val blacklist               = mock[Blacklist]
+      val (sendRequest, httpPool) = mockHttpPool()
+
+      val client =
+        new AkkaHttpClient(
+          AkkaHttpClientSettings(hosts).copy(maxRetryTimeout = 2.seconds),
+          blacklist,
+          httpPool
+        )
+
+      when(blacklist.contains("host1")).thenReturn(false, true, false)
+      when(blacklist.add("host1")).thenReturn(true)
+      when(blacklist.remove("host1")).thenReturn(false)
+
+      when(sendRequest
+        .apply(argThat { (r: HttpRequest) =>
+          r.uri == Uri("http://host1/test")
+        }))
+        .thenReturn(
+          Success(HttpResponse(StatusCodes.BadGateway)),
+          Success(HttpResponse().withEntity("ok"))
+        )
+
+      val startedAt = System.nanoTime()
+
+      client
+        .send(ElasticRequest("GET", "/test"))
+        .futureValue shouldBe ElasticResponse(
+        200,
+        Some(ElasticEntity.StringEntity("ok", None)),
+        Map.empty
+      )
+
+      val elapsed = (System.nanoTime() - startedAt).nanos
+      elapsed should be >= 80.millis
+      verify(sendRequest, times(2)).apply(any[HttpRequest])
+    }
+
     "blacklist on 502" in {
 
       val hosts = List(

--- a/elastic4s-client-pekko/src/main/scala/com/sksamuel/elastic4s/pekko/PekkoHttpClient.scala
+++ b/elastic4s-client-pekko/src/main/scala/com/sksamuel/elastic4s/pekko/PekkoHttpClient.scala
@@ -4,6 +4,7 @@ import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.http.scaladsl.model.Uri.Query
 import org.apache.pekko.http.scaladsl.model._
 import org.apache.pekko.http.scaladsl.model.headers.{BasicHttpCredentials, RawHeader}
+import org.apache.pekko.pattern.after
 import org.apache.pekko.stream.scaladsl.{FileIO, Keep, Sink, Source, StreamConverters}
 import org.apache.pekko.stream.{Materializer, OverflowStrategy, QueueOfferResult}
 import org.apache.pekko.util.ByteString
@@ -16,6 +17,7 @@ import com.sksamuel.elastic4s.{
 }
 
 import scala.concurrent.{Future, Promise}
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 class PekkoHttpClient private[pekko] (
@@ -129,13 +131,24 @@ class PekkoHttpClient private[pekko] (
 
     val state = RequestState()
 
+    val allHostsBlacklistedRetryDelay = 100.millis
+
     def retryIfPossible(
         notPossible: => Either[Throwable, ElasticHttpResponse]
     ): Future[ElasticHttpResponse] = {
-      val timePassed = System.nanoTime - startTimeNanos
+      val timePassed        = System.nanoTime - startTimeNanos
+      val hasAvailableHosts = settings.hosts.exists(host => !blacklist.contains(host))
+
       if (timePassed < settings.maxRetryTimeout.toNanos) {
-        logger.trace(s"Retrying a request: ${request.endpoint}")
-        queueRequestWithRetry(request, startTimeNanos)
+        if (hasAvailableHosts) {
+          logger.trace(s"Retrying a request immediately: ${request.endpoint}")
+          queueRequestWithRetry(request, startTimeNanos)
+        } else {
+          logger.trace(s"All hosts blacklisted, retrying with delay: ${request.endpoint}")
+          after(allHostsBlacklistedRetryDelay, system.scheduler) {
+            queueRequestWithRetry(request, startTimeNanos)
+          }
+        }
       } else {
         notPossible match {
           case Left(exc)   =>

--- a/elastic4s-client-pekko/src/test/scala/com/sksamuel/elastic4s/pekko/PekkoHttpClientMockTest.scala
+++ b/elastic4s-client-pekko/src/test/scala/com/sksamuel/elastic4s/pekko/PekkoHttpClientMockTest.scala
@@ -124,6 +124,47 @@ class PekkoHttpClientMockTest
       )
     }
 
+    "retry with delay when all hosts are blacklisted" in {
+
+      val hosts                   = List("host1")
+      val blacklist               = mock[Blacklist]
+      val (sendRequest, httpPool) = mockHttpPool()
+
+      val client =
+        new PekkoHttpClient(
+          PekkoHttpClientSettings(hosts).copy(maxRetryTimeout = 2.seconds),
+          blacklist,
+          httpPool
+        )
+
+      when(blacklist.contains("host1")).thenReturn(false, true, false)
+      when(blacklist.add("host1")).thenReturn(true)
+      when(blacklist.remove("host1")).thenReturn(false)
+
+      when(sendRequest
+        .apply(argThat { (r: HttpRequest) =>
+          r.uri == Uri("http://host1/test")
+        }))
+        .thenReturn(
+          Success(HttpResponse(StatusCodes.BadGateway)),
+          Success(HttpResponse().withEntity("ok"))
+        )
+
+      val startedAt = System.nanoTime()
+
+      client
+        .send(ElasticRequest("GET", "/test"))
+        .futureValue shouldBe ElasticResponse(
+        200,
+        Some(ElasticEntity.StringEntity("ok", None)),
+        Map.empty
+      )
+
+      val elapsed = (System.nanoTime() - startedAt).nanos
+      elapsed should be >= 80.millis
+      verify(sendRequest, times(2)).apply(any[HttpRequest])
+    }
+
     "blacklist on 502" in {
 
       val hosts = List(


### PR DESCRIPTION
Applying this PR will retry with a delay if all hosts are blacklisted. It would be even nicer if we used exponential backoff, but this should already be better.
Fixes https://github.com/Philippus/elastic4s/issues/3610.