### PR TITLE
Support script_fields in TopHitsAggregation

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/TopHitsAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/TopHitsAggregationBuilder.scala
@@ -1,6 +1,7 @@
 package com.sksamuel.elastic4s.requests.searches.aggs.builders
 
 import com.sksamuel.elastic4s.handlers.common.FetchSourceContextBuilderFn
+import com.sksamuel.elastic4s.handlers.script.ScriptBuilderFn
 import com.sksamuel.elastic4s.handlers.searches.HighlightBuilderFn
 import com.sksamuel.elastic4s.handlers.searches.queries.sort.SortBuilderFn
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
@@ -38,6 +39,16 @@ object TopHitsAggregationBuilder {
     }
 
     agg.version.foreach(builder.field("version", _))
+
+    if (agg.scripts.nonEmpty) {
+      builder.startObject("script_fields")
+      agg.scripts.foreach { case (name, script) =>
+        builder.startObject(name)
+        builder.rawField("script", ScriptBuilderFn(script))
+        builder.endObject()
+      }
+      builder.endObject()
+    }
 
     builder.endObject().endObject()
   }

--- a/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/TopHitsAggregationBuilderTest.scala
+++ b/elastic4s-core/src/test/scala/com/sksamuel/elastic4s/requests/searches/TopHitsAggregationBuilderTest.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.elastic4s.requests.searches
 
+import com.sksamuel.elastic4s.requests.script.Script
 import com.sksamuel.elastic4s.requests.searches.aggs.TopHitsAggregation
 import com.sksamuel.elastic4s.requests.searches.aggs.builders.TopHitsAggregationBuilder
 import com.sksamuel.elastic4s.requests.searches.sort.{FieldSort, SortMode}
@@ -25,5 +26,13 @@ class TopHitsAggregationBuilderTest extends AnyFunSuite with Matchers {
       .highlighting(HighlightField("name"))
     TopHitsAggregationBuilder(q).string shouldBe
       """{"top_hits":{"highlight":{"fields":{"name":{}}}}}"""
+  }
+
+  test("top hits aggregation builder should support script fields") {
+    val q = TopHitsAggregation("top_items")
+      .script("computed", Script("doc['price'].value * 2"))
+
+    TopHitsAggregationBuilder(q).string shouldBe
+      """{"top_hits":{"script_fields":{"computed":{"script":{"source":"doc['price'].value * 2"}}}}}"""
   }
 }


### PR DESCRIPTION
It was possible to define them, but they were not serialized. Fixes https://github.com/Philippus/elastic4s/issues/3640.