### PR TITLE
Emit the script field in ExtendedStatsAggregationBuilder (re-applies #2700)

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/ExtendedStatsAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/ExtendedStatsAggregationBuilder.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.elastic4s.requests.searches.aggs.builders
 
+import com.sksamuel.elastic4s.handlers
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.requests.searches.aggs.{
   AbstractAggregation,
@@ -18,6 +19,9 @@ object ExtendedStatsAggregationBuilder {
 
     builder.startObject("extended_stats")
     agg.field.foreach(builder.field("field", _))
+    agg.script.foreach { script =>
+      builder.rawField("script", handlers.script.ScriptBuilderFn(script))
+    }
     agg.sigma.foreach(builder.field("sigma", _))
     agg.missing.foreach(builder.autofield("missing", _))
 

--- a/elastic4s-tests/src/test/resources/json/search/search_aggregations_extendedstats.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_aggregations_extendedstats.json
@@ -2,7 +2,11 @@
     "aggs": {
         "grades_extendedstats": {
             "extended_stats": {
-                "field": "grade"
+                "field": "grade",
+                "script": {
+                    "lang": "lua",
+                    "source": "doc['grade'].value"
+                }
             }
         }
     }


### PR DESCRIPTION
## What

`ExtendedStatsAggregationBuilder` never serialises `agg.script`, although `ExtendedStatsAggregation` carries the field and the DSL accepts it. This adds the same emission every sibling metric builder already has, mirroring `MaxAggregationBuilder`'s idiom:

```scala
agg.script.foreach { script =>
  builder.rawField("script", handlers.script.ScriptBuilderFn(script))
}
```

## Why it matters

The failure is silent: with both a field and a script set, the emitted JSON contains only `"field"`, so Elasticsearch computes the extended stats **over the raw field** and returns a plausible, wrong number — no error anywhere. Checked against the current sources: `ExtendedStats` is the only one of the ten metric aggregation builders with this omission (Avg, Cardinality, Max, Min, Percentiles, Stats, Sum, ValueCount and WeightedAvg all emit `script`).

## History — this fix was already approved once

This is a re-application of #2700 (approved and merged on 2022-08-25), which landed on `release/7.10.x` and was never forward-ported — so the omission is still present in `7.17.25`, `8.18.x` and `series/9.x`. The patch here is #2700 adapted to the current `handlers.script.ScriptBuilderFn` location and the `customAggregations` signature.

## Test

The existing `SearchDslTest` case *"should generate correct json for extendedstats aggregation"* already sets `Script("doc['grade'].value").lang("lua")` on the aggregation — its golden fixture matched the dropped-script output, i.e. the test was pinning the bug. The fixture is updated to expect the script node (same fixture change as #2700).

```
sbt "tests/testOnly com.sksamuel.elastic4s.search.SearchDslTest -- -z extendedstats"
```

green locally on JDK 17 / sbt 2.0.8 — and verified **red without the builder change** (the fixture update alone fails against the unpatched builder), so the test genuinely asserts the emission.

## Backport ask

Would you consider a backport to the 7.17 line (a `7.17.26`)? We drive ES 6.x–9.x from one SQL engine ([SOFTNETWORK-APP/SoftClient4ES#222](https://github.com/SOFTNETWORK-APP/SoftClient4ES/issues/222)) on `nl.gn0s1s` 8.18.x and 7.17.25, and on 7.x our only current option is to reject scripted `extended_stats` loudly rather than let it answer wrongly. Happy to open the backport PR against the 7.17 branch if you point me at it.
