### PR TITLE
Emit the script field in ExtendedStatsAggregationBuilder (re-applies #2700) (series/7.x)

### DIFF
--- a/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/ExtendedStatsAggregationBuilder.scala
+++ b/elastic4s-core/src/main/scala/com/sksamuel/elastic4s/requests/searches/aggs/builders/ExtendedStatsAggregationBuilder.scala
@@ -1,5 +1,6 @@
 package com.sksamuel.elastic4s.requests.searches.aggs.builders
 
+import com.sksamuel.elastic4s.handlers
 import com.sksamuel.elastic4s.json.{XContentBuilder, XContentFactory}
 import com.sksamuel.elastic4s.requests.searches.aggs.{AggMetaDataFn, ExtendedStatsAggregation, SubAggsBuilderFn}
 
@@ -10,6 +11,9 @@ object ExtendedStatsAggregationBuilder {
 
     builder.startObject("extended_stats")
     agg.field.foreach(builder.field("field", _))
+    agg.script.foreach { script =>
+      builder.rawField("script", handlers.script.ScriptBuilderFn(script))
+    }
     agg.sigma.foreach(builder.field("sigma", _))
     agg.missing.foreach(builder.autofield("missing", _))
 

--- a/elastic4s-tests/src/test/resources/json/search/search_aggregations_extendedstats.json
+++ b/elastic4s-tests/src/test/resources/json/search/search_aggregations_extendedstats.json
@@ -2,7 +2,11 @@
     "aggs": {
         "grades_extendedstats": {
             "extended_stats": {
-                "field": "grade"
+                "field": "grade",
+                "script": {
+                    "lang": "lua",
+                    "source": "doc['grade'].value"
+                }
             }
         }
     }


### PR DESCRIPTION
## What / why

`ExtendedStatsAggregationBuilder` never serialised `agg.script`, although `ExtendedStatsAggregation` carries the field and the DSL accepts it — the only one of the ten metric aggregation builders with this omission (Avg, Cardinality, Max, Min, Percentiles, Stats, Sum, ValueCount and WeightedAvg all emit it). The failure is silent: with both a field and a script set, the emitted JSON contains only `"field"`, so Elasticsearch computes the extended stats over the raw field and returns a plausible, wrong number. This adds the same emission the sibling builders on `series/7.x` already use (`MaxAggregationBuilder` / `StatsAggregationBuilder` idiom, `handlers.script.ScriptBuilderFn`).

## Backport

Backport of #4100 to `series/7.x`, as requested in https://github.com/Philippus/elastic4s/pull/4100#issuecomment-5557794121:

> Nice catch! If you could make the same change towards the 7.x branch `series/7.x` and the 8.x branch `series/8.x` that would be great.

The commit is #4100's `38860e8` cherry-picked onto `series/7.x` (clean apply; 4 builder lines + the golden fixture).

## Test

The existing `SearchDslTest` case **"should generate correct json for extendedstats aggregation"** already sets `script("doc['grade'].value").lang("lua")` on the aggregation; its golden fixture `search_aggregations_extendedstats.json` matched the dropped-script output, i.e. it was pinning the bug. The fixture now expects the `script` node.

```
sbt "tests/testOnly com.sksamuel.elastic4s.search.SearchDslTest -- -z extendedstats"
```

Run locally on this branch (JDK 17 / sbt 2.0.8, same as CI):

- **green with** the builder change: `Tests: succeeded 1, failed 0`
- **red without** it (builder reverted to `series/7.x`, fixture kept): `Tests: succeeded 0, failed 1` — `{"aggs":{"grades_extendedstats":{"extended_stats":{"field":"grade"}}}} did not match resource [/json/search/search_aggregations_extendedstats.json]`

so the test genuinely asserts the emission.

Branch: `fupelaqu:fix/extended-stats-script-emission-7.x` — commit `3d4d7f0c4` on top of `series/7.x` @ `3f1d5a186`.
