### PR TITLE
Enable elastic4s-client-akka for scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -98,6 +98,7 @@ lazy val scala3Projects: Seq[ProjectReference] = Seq(
   clientcore,
   clientesjava,
   clientsSniffed,
+  clientakka,
   clientpekko,
   clienthttp4s,
   zio_1,
@@ -325,9 +326,7 @@ lazy val clientsttp4 = (project in file("elastic4s-client-sttp4"))
 lazy val clientakka = (project in file("elastic4s-client-akka"))
   .dependsOn(core, testkit % Test)
   .settings(name := "elastic4s-client-akka")
-  .settings(
-    scala2Settings
-  ) //  We need akka-http to be cross-published, which depends on an akka bump with restrictive licensing changes
+  .settings(scala3Settings)
   .settings(libraryDependencies ++= Seq(akkaHTTP, akkaStream, mockitoCore, scalaTestPlusMockito))
   .settings(
     Test / classLoaderLayeringStrategy := ClassLoaderLayeringStrategy.Raw,


### PR DESCRIPTION
Applying this PR will enable elastic4s-client-akka for scala 3. We've been on a scala 3 compatible version of akka-http for a while now, so this should work.