### PR TITLE
Add new synonyms-related fields

### DIFF
--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/CreateOrUpdateSynonymRuleRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/CreateOrUpdateSynonymRuleRequest.scala
@@ -1,3 +1,8 @@
 package com.sksamuel.elastic4s.requests.synonyms
 
-case class CreateOrUpdateSynonymRuleRequest(synonymsSet: String, synonymRule: String, synonyms: String)
+case class CreateOrUpdateSynonymRuleRequest(
+    synonymsSet: String,
+    synonymRule: String,
+    synonyms: String,
+    refresh: Option[Boolean] = None
+)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/CreateOrUpdateSynonymsSetRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/CreateOrUpdateSynonymsSetRequest.scala
@@ -1,3 +1,8 @@
 package com.sksamuel.elastic4s.requests.synonyms
 
-case class CreateOrUpdateSynonymsSetRequest(synonymsSet: String, synonymRules: Seq[SynonymRule])
+case class CreateOrUpdateSynonymsSetRequest(
+    synonymsSet: String,
+    synonymRules: Seq[SynonymRule],
+    refresh: Option[Boolean] = None,
+    append: Option[Boolean] = None
+)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/DeleteSynonymRuleRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/DeleteSynonymRuleRequest.scala
@@ -1,3 +1,3 @@
 package com.sksamuel.elastic4s.requests.synonyms
 
-case class DeleteSynonymRuleRequest(synonymsSet: String, synonymRule: String)
+case class DeleteSynonymRuleRequest(synonymsSet: String, synonymRule: String, refresh: Option[Boolean] = None)

--- a/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/GetSynonymsSetRequest.scala
+++ b/elastic4s-domain/src/main/scala/com/sksamuel/elastic4s/requests/synonyms/GetSynonymsSetRequest.scala
@@ -1,6 +1,12 @@
 package com.sksamuel.elastic4s.requests.synonyms
 
-case class GetSynonymsSetRequest(synonymsSet: String, from: Option[Int] = None, size: Option[Int] = None) {
-  def from(from: Int): GetSynonymsSetRequest = copy(from = Some(from))
-  def size(size: Int): GetSynonymsSetRequest = copy(size = Some(size))
+case class GetSynonymsSetRequest(
+    synonymsSet: String,
+    from: Option[Int] = None,
+    size: Option[Int] = None,
+    searchAfter: Option[String] = None
+) {
+  def from(from: Int): GetSynonymsSetRequest                  = copy(from = Some(from))
+  def size(size: Int): GetSynonymsSetRequest                  = copy(size = Some(size))
+  def searchAfter(searchAfter: String): GetSynonymsSetRequest = copy(searchAfter = Some(searchAfter))
 }

--- a/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/synonyms/SynonymsHandlers.scala
+++ b/elastic4s-handlers/src/main/scala/com/sksamuel/elastic4s/handlers/synonyms/SynonymsHandlers.scala
@@ -35,11 +35,14 @@ trait SynonymsHandlers {
 
     override def build(request: CreateOrUpdateSynonymsSetRequest): ElasticRequest = {
       val endpoint = s"/_synonyms/${request.synonymsSet}"
+      val params   = scala.collection.mutable.Map.empty[String, String]
+      request.refresh.foreach(refresh => params.put("refresh", refresh.toString))
+      request.append.foreach(append => params.put("append", append.toString))
 
       val body   = UpdateSynonymsBodyFn(request).string
       val entity = HttpEntity(body, "application/json")
 
-      ElasticRequest("PUT", endpoint, entity)
+      ElasticRequest("PUT", endpoint, params.toMap, entity)
     }
   }
 
@@ -59,6 +62,7 @@ trait SynonymsHandlers {
       val params   = scala.collection.mutable.Map.empty[String, String]
       request.from.foreach(from => params.put("from", from.toString))
       request.size.foreach(size => params.put("size", size.toString))
+      request.searchAfter.foreach(searchAfter => params.put("search_after", searchAfter))
       ElasticRequest("GET", endpoint, params.toMap)
     }
   }
@@ -112,9 +116,11 @@ trait SynonymsHandlers {
 
     override def build(request: CreateOrUpdateSynonymRuleRequest): ElasticRequest = {
       val endpoint = s"/_synonyms/${request.synonymsSet}/${request.synonymRule}"
+      val params   = scala.collection.mutable.Map.empty[String, String]
+      request.refresh.foreach(refresh => params.put("refresh", refresh.toString))
       val body     = UpdateSynonymRuleBodyFn(request).string
       val entity   = HttpEntity(body, "application/json")
-      ElasticRequest("PUT", endpoint, entity)
+      ElasticRequest("PUT", endpoint, params.toMap, entity)
     }
   }
 
@@ -148,7 +154,9 @@ trait SynonymsHandlers {
 
     override def build(request: DeleteSynonymRuleRequest): ElasticRequest = {
       val endpoint = s"/_synonyms/${request.synonymsSet}/${request.synonymRule}"
-      ElasticRequest("DELETE", endpoint)
+      val params   = scala.collection.mutable.Map.empty[String, String]
+      request.refresh.foreach(refresh => params.put("refresh", refresh.toString))
+      ElasticRequest("DELETE", endpoint, params.toMap)
     }
   }
 }

--- a/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/synonyms/SynonymsTest.scala
+++ b/elastic4s-tests/src/test/scala/com/sksamuel/elastic4s/requests/synonyms/SynonymsTest.scala
@@ -3,6 +3,7 @@ package com.sksamuel.elastic4s.requests.synonyms
 import scala.util.Try
 
 import com.sksamuel.elastic4s.ElasticDsl
+import com.sksamuel.elastic4s.handlers.synonyms.{UpdateSynonymRuleBodyFn, UpdateSynonymsBodyFn}
 import com.sksamuel.elastic4s.testkit.DockerTests
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -14,16 +15,76 @@ class SynonymsTest extends AnyFlatSpec with Matchers with ElasticDsl with Docker
     }.await.result
   }
 
+  private val rules = Seq(
+    SynonymRule(id = Some("test-1"), synonyms = "hello, hi"),
+    SynonymRule("bye, goodbye"),
+    SynonymRule(id = Some("test-2"), synonyms = "test => check")
+  )
+
+  // ---- request building (all fields) ----
+
+  "CreateOrUpdateSynonymsSetRequest" should "build the body from all synonym rules" in {
+    UpdateSynonymsBodyFn(CreateOrUpdateSynonymsSetRequest("my-synonyms-set", rules)).string shouldBe
+      """{"synonyms_set":[{"id":"test-1","synonyms":"hello, hi"},{"synonyms":"bye, goodbye"},{"id":"test-2","synonyms":"test => check"}]}"""
+  }
+
+  it should "wire refresh and append into the request params" in {
+    val request = CreateOrUpdateSynonymsSetRequest(
+      "my-synonyms-set",
+      rules,
+      refresh = Some(true),
+      append = Some(false)
+    )
+    val built   = UpdateSynonymsSetHandler.build(request)
+
+    built.method shouldBe "PUT"
+    built.endpoint shouldBe "/_synonyms/my-synonyms-set"
+    built.params shouldBe Map("refresh" -> "true", "append" -> "false")
+    built.entity.map(_.get) shouldBe Some(UpdateSynonymsBodyFn(request).string)
+  }
+
+  "GetSynonymsSetRequest" should "wire from, size and searchAfter into the request params" in {
+    val request = GetSynonymsSetRequest("my-synonyms-set")
+      .from(5)
+      .size(10)
+      .searchAfter("test-1")
+    val built   = GetSynonymsSetHandler.build(request)
+
+    built.method shouldBe "GET"
+    built.endpoint shouldBe "/_synonyms/my-synonyms-set"
+    built.params shouldBe Map("from" -> "5", "size" -> "10", "search_after" -> "test-1")
+  }
+
+  "CreateOrUpdateSynonymRuleRequest" should "build the body and wire refresh into the request params" in {
+    val request = CreateOrUpdateSynonymRuleRequest(
+      "my-synonyms-set",
+      "test-1",
+      "hello, hi, howdy",
+      refresh = Some(true)
+    )
+    val built   = UpdateSynonymRuleHandler.build(request)
+
+    built.method shouldBe "PUT"
+    built.endpoint shouldBe "/_synonyms/my-synonyms-set/test-1"
+    built.params shouldBe Map("refresh" -> "true")
+    UpdateSynonymRuleBodyFn(request).string shouldBe """{"synonyms":"hello, hi, howdy"}"""
+    built.entity.map(_.get) shouldBe Some(UpdateSynonymRuleBodyFn(request).string)
+  }
+
+  "DeleteSynonymRuleRequest" should "wire refresh into the request params" in {
+    val request = DeleteSynonymRuleRequest("my-synonyms-set", "test-1", refresh = Some(true))
+    val built   = DeleteSynonymRuleHandler.build(request)
+
+    built.method shouldBe "DELETE"
+    built.endpoint shouldBe "/_synonyms/my-synonyms-set/test-1"
+    built.params shouldBe Map("refresh" -> "true")
+  }
+
+  // ---- integration ----
+
   "synonyms" should "create a new set" in {
     val resp = client.execute {
-      createOrUpdateSynonymsSet(
-        "my-synonyms-set",
-        Seq(
-          SynonymRule(id = Some("test-1"), synonyms = "hello, hi"),
-          SynonymRule("bye, goodbye"),
-          SynonymRule(id = Some("test-2"), synonyms = "test => check")
-        )
-      )
+      createOrUpdateSynonymsSet("my-synonyms-set", rules)
     }.await.result
 
     resp.result shouldBe "created"
@@ -35,6 +96,13 @@ class SynonymsTest extends AnyFlatSpec with Matchers with ElasticDsl with Docker
     }.await.result
     resp.count shouldBe 3
     resp.synonymsSet.map(_.synonyms).toSet shouldBe Set("hello, hi", "bye, goodbye", "test => check")
+  }
+
+  it should "page a created set with from, size and searchAfter" in {
+    val resp = client.execute {
+      getSynonymsSet("my-synonyms-set").size(1).searchAfter("test-1")
+    }.await.result
+    resp.synonymsSet.size shouldBe 1
   }
 
   it should "handle errors" in {
@@ -54,6 +122,39 @@ class SynonymsTest extends AnyFlatSpec with Matchers with ElasticDsl with Docker
     resp.results.map(_.count).head shouldBe 3
   }
 
+  it should "append to an existing set" in {
+    val resp = client.execute {
+      CreateOrUpdateSynonymsSetRequest(
+        "my-synonyms-set",
+        Seq(SynonymRule(id = Some("test-3"), synonyms = "yes, yeah")),
+        append = Some(true)
+      )
+    }.await.result
+
+    resp.result shouldBe "updated"
+
+    val get = client.execute {
+      getSynonymsSet("my-synonyms-set")
+    }.await.result
+    get.count shouldBe 4
+  }
+
+  it should "update an existing rule" in {
+    val resp = client.execute {
+      upsertSynonymRule("my-synonyms-set", "test-1", "hello, hi, howdy")
+    }.await.result
+
+    resp.result shouldBe "updated"
+  }
+
+  it should "delete a synonym rule" in {
+    val resp = client.execute {
+      deleteSynonymRule("my-synonyms-set", "test-1")
+    }.await.result
+
+    resp.result shouldBe "deleted"
+  }
+
   it should "delete a set" in {
     client.execute {
       deleteSynonymsSet("my-synonyms-set")
@@ -64,43 +165,5 @@ class SynonymsTest extends AnyFlatSpec with Matchers with ElasticDsl with Docker
     }.await.result
 
     resp.count shouldBe 0
-  }
-
-  it should "update an existing rule" in {
-    client.execute {
-      createOrUpdateSynonymsSet(
-        "my-synonyms-set",
-        Seq(
-          SynonymRule(id = Some("test-1"), synonyms = "hello, hi"),
-          SynonymRule("bye, goodbye"),
-          SynonymRule(id = Some("test-2"), synonyms = "test => check")
-        )
-      )
-    }.await.result
-
-    val resp = client.execute {
-      upsertSynonymRule("my-synonyms-set", "test-1", "hello, hi, howdy")
-    }.await.result
-
-    resp.result shouldBe "updated"
-  }
-
-  it should "delete a synonym rule" in {
-    client.execute {
-      createOrUpdateSynonymsSet(
-        "my-synonyms-set",
-        Seq(
-          SynonymRule(id = Some("test-1"), synonyms = "hello, hi"),
-          SynonymRule("bye, goodbye"),
-          SynonymRule(id = Some("test-2"), synonyms = "test => check")
-        )
-      )
-    }.await.result
-
-    val resp = client.execute {
-      deleteSynonymRule("my-synonyms-set", "test-1")
-    }.await.result
-
-    resp.result shouldBe "deleted"
   }
 }


### PR DESCRIPTION
Applying this PR updates synonyms-related fields to current (9.5.0) api: https://www.elastic.co/docs/api/doc/elasticsearch/group/endpoint-synonyms.